### PR TITLE
Update teams structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,25 +2,21 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # Specific files
-setup.cfg @plugwise/devs
-setup.py @plugwise/devs
-pyproject.toml @plugwise/devs
-requirements*.txt @plugwise/devs
+setup.cfg @plugwise/plugwise-usb
+setup.py @plugwise/plugwise-usb
+pyproject.toml @plugwise/plugwise-usb
+requirements*.txt @plugwise/plugwise-usb
 
 # Main code
-/plugwise/ @plugwise/devs
-/userdata/ @plugwise/devs
+/plugwise/ @plugwise/plugwise-usb
+/userdata/ @plugwise/plugwise-usb
 
 # Tests and development support
-/tests/ @bouwew @compatech
-/scripts/ @bouwew @compatech
+/tests/ @plugwise/plugwise-usb
+/scripts/ @compatech
 
 # USB specific
-/plugwise/connections/ @brefra
-/plugwise/controller.py @bouwew @brefra
-/plugwise/messages/ @brefra
-/plugwise/nodes/ @brefra
-/plugwise/parser.py @brefra
-/plugwise/stick.py @brefra
-/plugwise/util.py @brefra
+/plugwise/controller.py @bouwew @plugwise/plugwise-usb
 
+# Generic
+* @plugwise/plugwise-usb


### PR DESCRIPTION
Create dnew Github teams differentiating the repositories and aligning CODEOWNERS. Reviewers should update so respective owners get less e-mail requesting reviews.