### PR TITLE
Fix flooding of plugwise network by CircleEnergyCountersRequest

### DIFF
--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -617,7 +617,7 @@ class PlugwiseCircle(PlugwiseNode):
         if log_address is not None:
             if self._energy_history_collecting and (
                 self._energy_history_collecting_timestamp
-                < datetime.now() - timedelta(minutes=15)
+                > datetime.now() - timedelta(minutes=15)
             ):
                 _LOGGER.debug(
                     "Skip request_energy_counters for %s of address %s",
@@ -635,6 +635,8 @@ class PlugwiseCircle(PlugwiseNode):
                     self._request_info(self.request_energy_counters)
                 else:
                     # Request new energy counters
+					self._energy_history_collecting = True
+					self._energy_history_collecting_timestamp = datetime.now()
                     if self._energy_memory.get(log_address, 0) < 4:
                         self.message_sender(
                             CircleEnergyCountersRequest(self._mac, log_address),


### PR DESCRIPTION
While not having traced back fully to the origin this is what was happening:
At some point the current (ongoing) memory slot of the energy counters is being requested repeatedly, flooding the Stick / Network.
(1) On line 611 (original) it is checked whether any CircleEnergyCountersRequest have been sent recently, however this always resolved as true as long as the last request is more recent than 15 minutes using self._energy_history_collecting_timestamp
(2) On line 631 (original) an update CircleEnergyCountersRequest was being sent, however _energy_history_collecting_timestamp was not set.

(1) and (2) are resolved, but (1) requires checking whether was really a mistake or intentional behaviour.