### PR TITLE
second attempt at stop flooding of CircleEnergyCountersRequests

### DIFF
--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -413,7 +413,11 @@ class PlugwiseCircle(PlugwiseNode):
                     str(self._energy_last_populated_slot),
                     str(self._energy_last_collected_timestamp),
                 )
-                self.request_energy_counters(_mem_address)
+                #Rate limit repeat request of failed answer until hour rollover
+                if self._energy_last_collected_timestamp < datetime.utcnow().replace(
+                    minute=0, second=0, microsecond=0
+                ):
+                    self.request_energy_counters(_mem_address)
                 _energy_history_failed = True
 
         # Validate all history values where present
@@ -628,8 +632,6 @@ class PlugwiseCircle(PlugwiseNode):
                     self._request_info(self.request_energy_counters)
                 else:
                     # Request new energy counters
-                    self._energy_history_collecting = True
-                    self._energy_history_collecting_timestamp = datetime.now()
                     if self._energy_memory.get(log_address, 0) < 4:
                         self.message_sender(
                             CircleEnergyCountersRequest(self._mac, log_address),


### PR DESCRIPTION
In the previous fix I was misusing _energy_history_collecting[_timestamp], which has a somewhat different intention than blocking these repeated requests.

I have found that in some cases the most current log_address returns an incomplete answer which results in an error in _collect_energy_pulses which would resend the request, which results in a quick stacking up of back and forth with the plug.
If have limited this repeat based on _energy_last_collected_timestamp. A possible side-effect can be that a faulty answer from not the most current log_address does not get repeated. If we see problems there, we might think of a different way to limit the number of retries.