### PR TITLE
make sure log addresses are unique inside history_failed_address

### DIFF
--- a/plugwise_usb/controller.py
+++ b/plugwise_usb/controller.py
@@ -128,8 +128,9 @@ class StickMessageController:
     ):
         """Queue request message to be sent into Plugwise Zigbee network."""
         _LOGGER.debug(
-            "Queue %s to be send with retry counter %s and priority %s",
+            "Queue %s to be send to %s with retry counter %s and priority %s",
             request.__class__.__name__,
+            request.mac,
             str(retry_counter),
             str(priority),
         )

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -419,7 +419,8 @@ class PlugwiseCircle(PlugwiseNode):
                 )
             else:
                 _mem_address = self._energy_timestamp_memory_address(_log_timestamp)
-                self._energy_history_failed_address.append(_mem_address)
+                if self._energy_history_failed_address.count(_mem_address) == 0
+                    self._energy_history_failed_address.append(_mem_address)
                 _LOGGER.info(
                     "_collect_energy_pulses for %s at %s not found, request counter from memory %s (from mem=%s, slot=%s, timestamp=%s)",
                     self.mac,

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -419,7 +419,7 @@ class PlugwiseCircle(PlugwiseNode):
                 )
             else:
                 _mem_address = self._energy_timestamp_memory_address(_log_timestamp)
-                if self._energy_history_failed_address.count(_mem_address) == 0
+                if self._energy_history_failed_address.count(_mem_address) == 0:
                     self._energy_history_failed_address.append(_mem_address)
                 _LOGGER.info(
                     "_collect_energy_pulses for %s at %s not found, request counter from memory %s (from mem=%s, slot=%s, timestamp=%s)",


### PR DESCRIPTION
the log addresses each contain 4 hours of data and thus could be added to the history_failed_address multiple times, also when the update cycle rotates faster than the recalls of the failed adresses. Therefore it is good to prevent the addresses inside the array are unique.

Small update to the logging to include mac address for easier tracing.