### PR TITLE
Add support for devices with production enabled - try 4

### DIFF
--- a/plugwise_usb/api.py
+++ b/plugwise_usb/api.py
@@ -216,14 +216,10 @@ class EnergyStatistics:
     hour_consumption_reset: datetime | None = None
     day_consumption: float | None = None
     day_consumption_reset: datetime | None = None
-    week_consumption: float | None = None
-    week_consumption_reset: datetime | None = None
     hour_production: float | None = None
     hour_production_reset: datetime | None = None
     day_production: float | None = None
     day_production_reset: datetime | None = None
-    week_production: float | None = None
-    week_production_reset: datetime | None = None
 
 
 class PlugwiseNode(Protocol):

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -283,15 +283,9 @@ class EnergyCounter:
             # No syncing needed for the hour-counters, they reset when the device pulsecounter(s) reset
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
-            # Sync the daily reset time with the device pulsecounter(s) reset time
-            last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-            if pulse_collection.hourly_reset_time is not None:
-                last_reset = last_reset.replace(
-                    hour=0,
-                    minute=pulse_collection.hourly_reset_time.minute,
-                    second=pulse_collection.hourly_reset_time.second,
-                    microsecond=pulse_collection.hourly_reset_time.microsecond,
-                )
+            # Postpone the daily reset time change until the device pulsecounter(s) reset
+            if pulse_collection.pulse_counter_reset:
+                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -299,11 +299,11 @@ class EnergyCounter:
                     hour=0, minute=0, second=0, microsecond=0
                 )
             else:
-                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
                 if last_reset.hour == 0 and pulse_collection.pulse_counter_reset:
                     self._midnight_reset_passed = True
                 if last_reset.hour == 1 and self._midnight_reset_passed:
                     self._midnight_reset_passed = False
+                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -280,9 +280,6 @@ class EnergyCounter:
     ) -> tuple[float | None, datetime | None]:
         """Get pulse update."""
         last_reset = datetime.now(tz=LOCAL_TIMEZONE)
-        if self._midnight_reset_passed and last_reset.hour == 1:
-            self._midnight_reset_passed = False
-
         if self._energy_id in ENERGY_HOUR_COUNTERS:
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
@@ -303,8 +300,10 @@ class EnergyCounter:
                 )
             else:
                 last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-                if pulse_collection.pulse_counter_reset:
+                if last_reset.hour == 0 and pulse_collection.pulse_counter_reset:
                     self._midnight_reset_passed = True
+                if last_reset.hour == 1 and self._midnight_reset_passed:
+                    self._midnight_reset_passed = False
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -206,7 +206,6 @@ class EnergyCounter:
             self._is_consumption = False
         self._last_reset: datetime | None = None
         self._last_update: datetime | None = None
-        self._pulse_collection = PulseCollection(mac)
         self._pulses: int | None = None
 
     @property
@@ -289,12 +288,12 @@ class EnergyCounter:
         if self._energy_id in ENERGY_DAY_COUNTERS:
             # Sync the daily reset time with the device pulsecounter(s) reset time
             last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-            if self._pulse_collection.last_hourly_reset is not None:
+            if pulse_collection.last_hourly_reset is not None:
                 last_reset = last_reset.replace(
                     hour=0,
-                    minute=self._pulse_collection.last_hourly_reset.minutes,
-                    second=self._pulse_collection.last_hourly_reset.seconds,
-                    microsecond=self._pulse_collection.last_hourly_reset.microseconds,
+                    minute=pulse_collection.last_hourly_reset.minutes,
+                    second=pulse_collection.last_hourly_reset.seconds,
+                    microsecond=pulse_collection.last_hourly_reset.microseconds,
                 )
 
         pulses, last_update = pulse_collection.collected_pulses(

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -291,9 +291,9 @@ class EnergyCounter:
             if pulse_collection.last_hourly_reset is not None:
                 last_reset = last_reset.replace(
                     hour=0,
-                    minute=pulse_collection.last_hourly_reset.minutes,
-                    second=pulse_collection.last_hourly_reset.seconds,
-                    microsecond=pulse_collection.last_hourly_reset.microseconds,
+                    minute=pulse_collection.last_hourly_reset.minute,
+                    second=pulse_collection.last_hourly_reset.second,
+                    microsecond=pulse_collection.last_hourly_reset.microsecond,
                 )
 
         pulses, last_update = pulse_collection.collected_pulses(

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -301,7 +301,8 @@ class EnergyCounter:
                 last_reset = (last_reset - timedelta(days=1)).replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
-                self._midnight_reset_passed = True
+                if pulse_collection.pulse_counter_reset:
+                    self._midnight_reset_passed = True
             else:
                 last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -297,7 +297,7 @@ class EnergyCounter:
                         microsecond=self._pulse_collection.consumption_last_hourly_reset.microseconds,
                     )
                 else:
-                    last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
+                    last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
             elif self._pulse_collection.production_last_hourly_reset is not None:
                 last_reset = last_reset.replace(
                     hour=0,

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -288,6 +288,12 @@ class EnergyCounter:
         if self._energy_id in ENERGY_DAY_COUNTERS:
             last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
             # Postpone the last_reset time-changes at day-end until a device pulsecounter resets
+            _LOGGER.debug("energycounter_update | last reset hour=%s", last_reset.hour)
+            _LOGGER.debug(
+                "energycounter_update | pulse_counter_reset=%s, midnight_reset_passed=%s",
+                pulse_collection.pulse_counter_reset,
+                self._midnight_reset_passed,
+            )
             if last_reset.hour == 0 and (
                 not pulse_collection.pulse_counter_reset
                 and not self._midnight_reset_passed

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -283,7 +283,7 @@ class EnergyCounter:
             # No syncing needed for the hour-counters, they reset when the device pulsecounter(s) reset
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
-            # Postpone the daily reset time change until the device pulsecounter(s) reset
+            # Postpone the daily last_reset time-change until a device pulsecounter resets
             if pulse_collection.pulse_counter_reset:
                 last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -288,25 +288,14 @@ class EnergyCounter:
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
             # Sync the daily reset time with the device pulsecounter(s) reset time
-            if self._is_consumption:
-                if self._pulse_collection.consumption_last_hourly_reset is not None:
-                    last_reset = last_reset.replace(
-                        hour=0,
-                        minute=self._pulse_collection.consumption_last_hourly_reset.minutes,
-                        second=self._pulse_collection.consumption_last_hourly_reset.seconds,
-                        microsecond=self._pulse_collection.consumption_last_hourly_reset.microseconds,
-                    )
-                else:
-                    last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-            elif self._pulse_collection.production_last_hourly_reset is not None:
+            last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
+            if self._pulse_collection.last_hourly_reset is not None:
                 last_reset = last_reset.replace(
                     hour=0,
-                    minute=self._pulse_collection.production_last_hourly_reset.minutes,
-                    second=self._pulse_collection.production_last_hourly_reset.seconds,
-                    microsecond=self._pulse_collection.production_last_hourly_reset.microseconds,
+                    minute=self._pulse_collection.last_hourly_reset.minutes,
+                    second=self._pulse_collection.last_hourly_reset.seconds,
+                    microsecond=self._pulse_collection.last_hourly_reset.microseconds,
                 )
-            else:
-                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -284,9 +284,27 @@ class EnergyCounter:
         """Get pulse update."""
         last_reset = datetime.now(tz=LOCAL_TIMEZONE)
         if self._energy_id in ENERGY_HOUR_COUNTERS:
+            # No syncing needed for the hour-counters, they reset when the device pulsecounter(s) reset
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
-            last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
+            # Sync the daily reset time with the device pulsecounter(s) reset time
+            if self._is_consumption:
+                if self._pulse_collection.consumption_last_hourly_reset is not None:
+                    last_reset = last_reset.replace(
+                        hour=0,
+                        minute=self._pulse_collection.consumption_last_hourly_reset.minutes,
+                        second=self._pulse_collection.consumption_last_hourly_reset.seconds,
+                        microsecond=self._pulse_collection.consumption_last_hourly_reset.microseconds,
+                    )
+            elif self._pulse_collection.production_last_hourly_reset is not None:
+                last_reset = last_reset.replace(
+                    hour=0,
+                    minute=self._pulse_collection.production_last_hourly_reset.minutes,
+                    second=self._pulse_collection.production_last_hourly_reset.seconds,
+                    microsecond=self._pulse_collection.production_last_hourly_reset.microseconds,
+                )
+            else:
+                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -286,14 +286,14 @@ class EnergyCounter:
         if self._energy_id in ENERGY_HOUR_COUNTERS:
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
-            last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-            # Postpone the last_reset time-changes at day-end until a device pulsecounter resets
+            reset: bool = pulse_collection.pulse_counter_reset
             _LOGGER.debug("energycounter_update | last reset hour=%s", last_reset.hour)
             _LOGGER.debug(
                 "energycounter_update | pulse_counter_reset=%s, midnight_reset_passed=%s",
-                pulse_collection.pulse_counter_reset,
+                reset,
                 self._midnight_reset_passed,
             )
+            # Postpone the last_reset time-changes at day-end until a device pulsecounter resets
             if last_reset.hour == 0 and (
                 not pulse_collection.pulse_counter_reset
                 and not self._midnight_reset_passed
@@ -302,6 +302,8 @@ class EnergyCounter:
                     hour=0, minute=0, second=0, microsecond=0
                 )
                 self._midnight_reset_passed = True
+            else:
+                last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -283,13 +283,6 @@ class EnergyCounter:
         if self._energy_id in ENERGY_HOUR_COUNTERS:
             last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
         if self._energy_id in ENERGY_DAY_COUNTERS:
-            reset: bool = pulse_collection.pulse_counter_reset
-            _LOGGER.debug("energycounter_update | last reset hour=%s", last_reset.hour)
-            _LOGGER.debug(
-                "energycounter_update | pulse_counter_reset=%s, midnight_reset_passed=%s",
-                reset,
-                self._midnight_reset_passed,
-            )
             # Postpone the last_reset time-changes at day-end until a device pulsecounter resets
             if last_reset.hour == 0 and (
                 not pulse_collection.pulse_counter_reset

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -296,6 +296,8 @@ class EnergyCounter:
                         second=self._pulse_collection.consumption_last_hourly_reset.seconds,
                         microsecond=self._pulse_collection.consumption_last_hourly_reset.microseconds,
                     )
+                else:
+                    last_reset = last_reset.replace(minute=0, second=0, microsecond=0)
             elif self._pulse_collection.production_last_hourly_reset is not None:
                 last_reset = last_reset.replace(
                     hour=0,

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -301,10 +301,10 @@ class EnergyCounter:
                 last_reset = (last_reset - timedelta(days=1)).replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
-                if pulse_collection.pulse_counter_reset:
-                    self._midnight_reset_passed = True
             else:
                 last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
+                if pulse_collection.pulse_counter_reset:
+                    self._midnight_reset_passed = True
 
         pulses, last_update = pulse_collection.collected_pulses(
             last_reset, self._is_consumption

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -285,12 +285,12 @@ class EnergyCounter:
         if self._energy_id in ENERGY_DAY_COUNTERS:
             # Sync the daily reset time with the device pulsecounter(s) reset time
             last_reset = last_reset.replace(hour=0, minute=0, second=0, microsecond=0)
-            if pulse_collection.last_hourly_reset is not None:
+            if pulse_collection.hourly_reset_time is not None:
                 last_reset = last_reset.replace(
                     hour=0,
-                    minute=pulse_collection.last_hourly_reset.minute,
-                    second=pulse_collection.last_hourly_reset.second,
-                    microsecond=pulse_collection.last_hourly_reset.microsecond,
+                    minute=pulse_collection.hourly_reset_time.minute,
+                    second=pulse_collection.hourly_reset_time.second,
+                    microsecond=pulse_collection.hourly_reset_time.microsecond,
                 )
 
         pulses, last_update = pulse_collection.collected_pulses(

--- a/plugwise_usb/nodes/helpers/counter.py
+++ b/plugwise_usb/nodes/helpers/counter.py
@@ -146,9 +146,6 @@ class EnergyCounters:
         self._energy_statistics.log_interval_consumption = (
             self._pulse_collection.log_interval_consumption
         )
-        self._energy_statistics.log_interval_production = (
-            self._pulse_collection.log_interval_production
-        )
         (
             self._energy_statistics.hour_consumption,
             self._energy_statistics.hour_consumption_reset,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -301,6 +301,7 @@ class PulseCollection:
             and self._pulses_production < pulses_produced 
         ):
             self._prod_pulsecounter_reset = True
+            self._last_hourly_reset = timestamp
             _LOGGER.debug(
                 "update_pulse_counter | production pulses reset | hourly_reset_time=%s",
                 self._last_hourly_reset,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -302,10 +302,10 @@ class PulseCollection:
         ):
             self._prod_pulsecounter_reset = True
             _LOGGER.debug("update_pulse_counter | production pulses reset")
-            self.prod_last_hourly_reset = timestamp
+            self._prod_last_hourly_reset = timestamp
             _LOGGER.debug(
                 "update_pulse_counter | production hourly_reset_time=%s",
-                self.prod_last_hourly_reset,
+                self._prod_last_hourly_reset,
             )
 
         # No rollover based on time, check rollover based on counter reset
@@ -768,8 +768,7 @@ class PulseCollection:
             return
 
         log_time_stamp = self._logs[address][slot].timestamp
-        is_consumption = self._logs[address][slot].is_consumption
-        if is_consumption:
+        if (is_consumption := self._logs[address][slot].is_consumption):
             if self._cons_last_hourly_reset is not None:
                 log_time_stamp = log_time_stamp + timedelta(
                     minutes=self._cons_last_hourly_reset.minute,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -172,6 +172,23 @@ class PulseCollection:
         self, from_timestamp: datetime, is_consumption: bool
     ) -> tuple[int | None, datetime | None]:
         """Calculate total pulses from given timestamp."""
+
+        # Sync from_timestamp with the device pulsecounter reset-time
+        # This syncs the hourly/daily reset of energy counters with the corresponding device pulsecounter reset
+        if is_consumption:
+            if self._cons_last_hourly_reset is not None :
+                from_timestamp = from_timestamp + timedelta(
+                    minutes=self._cons_last_hourly_reset.minute,
+                    seconds=self._cons_last_hourly_reset.second,
+                    microseconds=self._cons_last_hourly_reset.microsecond,
+                )
+        elif self._prod_last_hourly_reset is not None:
+            from_timestamp = from_timestamp + timedelta(
+                minutes=self._prod_last_hourly_reset.minute,
+                seconds=self._prod_last_hourly_reset.second,
+                microseconds=self._prod_last_hourly_reset.microsecond,
+            )
+        
         _LOGGER.debug(
             "collected_pulses | %s | from_timestamp=%s | is_cons=%s | _log_production=%s",
             self._mac,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -286,29 +286,29 @@ class PulseCollection:
         self._prod_pulsecounter_reset = False
         self._pulses_timestamp = timestamp
         self._update_rollover()
-        if self._pulses_consumption is not None:
-            self._pulses_consumption = pulses_consumed
-            _LOGGER.debug("update_pulse_counter | consumption pulses=%s", self._pulses_consumption)
-            if self._pulses_consumption > pulses_consumed:
-                self._cons_pulsecounter_reset = True
-                _LOGGER.debug("update_pulse_counter | consumption pulses reset")
-                self._cons_last_hourly_reset = timestamp
-                _LOGGER.debug(
-                    "update_pulse_counter | consumption hourly_reset_time=%s",
-                    self._cons_last_hourly_reset,
-                )
+        if (
+            self._pulses_consumption is not None
+            and self._pulses_consumption > pulses_consumed
+        ):
+            self._cons_pulsecounter_reset = True
+            _LOGGER.debug("update_pulse_counter | consumption pulses reset")
+            self._cons_last_hourly_reset = timestamp
+            _LOGGER.debug(
+                "update_pulse_counter | consumption hourly_reset_time=%s",
+                self._cons_last_hourly_reset,
+            )
 
-        if self._pulses_production is not None:
-            self._pulses_production = pulses_produced
-            _LOGGER.debug("update_pulse_counter | production pulses=%s", self._pulses_production)
-            if self._pulses_production < pulses_produced:
-                self._prod_pulsecounter_reset = True
-                _LOGGER.debug("update_pulse_counter | production pulses reset")
-                self.prod_last_hourly_reset = timestamp
-                _LOGGER.debug(
-                    "update_pulse_counter | production hourly_reset_time=%s",
-                    self.prod_last_hourly_reset,
-                )
+        if (
+            self._pulses_production is not None
+            and self._pulses_production < pulses_produced 
+        ):
+            self._prod_pulsecounter_reset = True
+            _LOGGER.debug("update_pulse_counter | production pulses reset")
+            self.prod_last_hourly_reset = timestamp
+            _LOGGER.debug(
+                "update_pulse_counter | production hourly_reset_time=%s",
+                self.prod_last_hourly_reset,
+            )
 
         # No rollover based on time, check rollover based on counter reset
         # Required for special cases like nodes which have been powered off for several days
@@ -320,6 +320,11 @@ class PulseCollection:
             if self._prod_pulsecounter_reset:
                 _LOGGER.debug("update_pulse_counter | rollover production")
                 self._rollover_production = True
+
+        self._pulses_consumption = pulses_consumed
+        _LOGGER.debug("update_pulse_counter | consumption pulses=%s", self._pulses_consumption)
+        self._pulses_production = pulses_produced
+        _LOGGER.debug("update_pulse_counter | production pulses=%s", self._pulses_production)
 
     def _update_rollover(self) -> None:
         """Update rollover states.

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -119,7 +119,7 @@ class PulseCollection:
         if self._logs is None:
             return {}
         sorted_log: dict[int, dict[int, PulseLogRecord]] = {}
-        skip_before = datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # Should this timedelta be adapted?
+        skip_before = datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
         sorted_addresses = sorted(self._logs.keys(), reverse=True)
         for address in sorted_addresses:
             sorted_slots = sorted(self._logs[address].keys(), reverse=True)
@@ -461,7 +461,7 @@ class PulseCollection:
     def recalculate_missing_log_addresses(self) -> None:
         """Recalculate missing log addresses."""
         self._log_addresses_missing = self._logs_missing(
-            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # idem
+            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
         )
 
     def _add_log_record(
@@ -480,7 +480,7 @@ class PulseCollection:
 
         # Drop useless log records when we have at least 4 logs
         if self.collected_logs > 4 and log_record.timestamp < (
-            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # idem
+            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
         ):
             return False
 

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -768,6 +768,8 @@ class PulseCollection:
             return
 
         log_time_stamp = self._logs[address][slot].timestamp
+        # Sync log_time_stamp with the device pulsecounter reset-time
+        # This syncs the daily reset of energy counters with the corresponding device pulsecounter reset
         if (is_consumption := self._logs[address][slot].is_consumption):
             if self._cons_last_hourly_reset is not None:
                 log_time_stamp = log_time_stamp + timedelta(

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -124,7 +124,7 @@ class PulseCollection:
         if self._logs is None:
             return {}
         sorted_log: dict[int, dict[int, PulseLogRecord]] = {}
-        skip_before = datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
+        skip_before = datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # Should this timedelta be adapted?
         sorted_addresses = sorted(self._logs.keys(), reverse=True)
         for address in sorted_addresses:
             sorted_slots = sorted(self._logs[address].keys(), reverse=True)
@@ -462,7 +462,7 @@ class PulseCollection:
     def recalculate_missing_log_addresses(self) -> None:
         """Recalculate missing log addresses."""
         self._log_addresses_missing = self._logs_missing(
-            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
+            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # idem
         )
 
     def _add_log_record(
@@ -481,7 +481,7 @@ class PulseCollection:
 
         # Drop useless log records when we have at least 4 logs
         if self.collected_logs > 4 and log_record.timestamp < (
-            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
+            datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)  # idem
         ):
             return False
 

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -755,15 +755,6 @@ class PulseCollection:
 
         log_timestamp = self._logs[address][slot].timestamp
         is_consumption = self._logs[address][slot].is_consumption
-        # Sync log_timestamp with the device pulsecounter reset-time
-        # This syncs the daily reset of energy counters with the corresponding device pulsecounter reset
-        if self._last_hourly_reset is not None:
-            log_timestamp = log_timestamp + timedelta(
-                minutes=self._last_hourly_reset.minute,
-                seconds=self._last_hourly_reset.second,
-                microseconds=self._last_hourly_reset.microsecond,
-            )
-
         # Update log references
         self._update_first_log_reference(address, slot, log_timestamp, is_consumption)
         self._update_last_log_reference(address, slot, log_timestamp, is_consumption)

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -107,13 +107,6 @@ class PulseCollection:
         return counter
 
     @property
-    def hourly_reset_time(self) -> datetime | None:
-        """Provide the device hourly pulse reset time.""" 
-        if (timestamp := self._last_hourly_reset) is not None:
-            return timestamp
-        return None
-
-    @property
     def logs(self) -> dict[int, dict[int, PulseLogRecord]]:
         """Return currently collected pulse logs in reversed order."""
         if self._logs is None:
@@ -291,22 +284,15 @@ class PulseCollection:
             and self._pulses_consumption > pulses_consumed
         ):
             self._cons_pulsecounter_reset = True
-            self._last_hourly_reset = timestamp
-            _LOGGER.debug(
-                "update_pulse_counter | consumption pulses reset | hourly_reset_time=%s",
-                self._last_hourly_reset,
-            )
+            _LOGGER.debug("update_pulse_counter | consumption pulses reset")
 
         if (
             self._pulses_production is not None
             and self._pulses_production < pulses_produced 
         ):
             self._prod_pulsecounter_reset = True
-            self._last_hourly_reset = timestamp
-            _LOGGER.debug(
-                "update_pulse_counter | production pulses reset | hourly_reset_time=%s",
-                self._last_hourly_reset,
-            )
+            _LOGGER.debug("update_pulse_counter | production pulses reset")
+
         # No rollover based on time, set rollover based on counter reset
         # Required for special cases like nodes which have been powered off for several days
         if not (self._rollover_consumption or self._rollover_production):

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -108,6 +108,16 @@ class PulseCollection:
         return counter
 
     @property
+    def consumption_last_hourly_reset(self) -> datetime | None:
+        """Consumption last hourly reset."""
+        return self._cons_last_hourly_reset
+
+    @property
+    def production_last_hourly_reset(self) -> datetime | None:
+        """Production last hourly reset."""
+        return self._prod_last_hourly_reset
+
+    @property
     def hourly_reset_time(self) -> datetime | None:
         """Provide the device hourly pulse reset time, using in testing.""" 
         if (timestamp := self._cons_last_hourly_reset) is not None:
@@ -172,23 +182,6 @@ class PulseCollection:
         self, from_timestamp: datetime, is_consumption: bool
     ) -> tuple[int | None, datetime | None]:
         """Calculate total pulses from given timestamp."""
-
-        # Sync from_timestamp with the device pulsecounter reset-time
-        # This syncs the hourly/daily reset of energy counters with the corresponding device pulsecounter reset
-        if is_consumption:
-            if self._cons_last_hourly_reset is not None :
-                from_timestamp = from_timestamp + timedelta(
-                    minutes=self._cons_last_hourly_reset.minute,
-                    seconds=self._cons_last_hourly_reset.second,
-                    microseconds=self._cons_last_hourly_reset.microsecond,
-                )
-        elif self._prod_last_hourly_reset is not None:
-            from_timestamp = from_timestamp + timedelta(
-                minutes=self._prod_last_hourly_reset.minute,
-                seconds=self._prod_last_hourly_reset.second,
-                microseconds=self._prod_last_hourly_reset.microsecond,
-            )
-        
         _LOGGER.debug(
             "collected_pulses | %s | from_timestamp=%s | is_cons=%s | _log_production=%s",
             self._mac,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -109,7 +109,7 @@ class PulseCollection:
 
     @property
     def hourly_reset_time(self) -> datetime | None:
-        """Provide the device hourly pulse reset time.""" 
+        """Provide the device hourly pulse reset time, using in testing.""" 
         if (timestamp := self._cons_last_hourly_reset) is not None:
             return timestamp
         if (timestamp := self._prod_last_hourly_reset) is not None:

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -322,9 +322,12 @@ class PulseCollection:
                 self._rollover_production = True
 
         self._pulses_consumption = pulses_consumed
-        _LOGGER.debug("update_pulse_counter | consumption pulses=%s", self._pulses_consumption)
         self._pulses_production = pulses_produced
-        _LOGGER.debug("update_pulse_counter | production pulses=%s", self._pulses_production)
+        _LOGGER.debug(
+            "update_pulse_counter | consumption pulses=%s | production pulses=%s",
+            self._pulses_consumption,
+            self._pulses_production,
+        )
 
     def _update_rollover(self) -> None:
         """Update rollover states.

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -236,7 +236,6 @@ class PulseCollection:
                 return None
 
             timestamp = self._last_log_consumption_timestamp
-            _LOGGER.debug("HOI _last_log_consumption_timestamp=%s", self._last_log_consumption_timestamp)
         else:
             if self._last_log_production_timestamp is None:
                 _LOGGER.debug(
@@ -246,7 +245,6 @@ class PulseCollection:
                 return None
 
             timestamp = self._last_log_production_timestamp
-            _LOGGER.debug("HOI _last_log_production_timestamp=%s", self._last_log_production_timestamp)
 
         missing_logs = self._logs_missing(from_timestamp)
         if missing_logs is None or missing_logs:

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -257,7 +257,7 @@ class PulseCollection:
             return None
 
         log_pulses = 0
-        for log_item in self._logs.values():
+        for log_item in self.logs.values():
             for slot_item in log_item.values():
                 if (
                     slot_item.is_consumption == is_consumption

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -764,6 +764,7 @@ class PulseCollection:
             return
 
         log_timestamp = self._logs[address][slot].timestamp
+        is_consumption = self._logs[address][slot].is_consumption
         # Sync log_timestamp with the device pulsecounter reset-time
         # This syncs the daily reset of energy counters with the corresponding device pulsecounter reset
         if self._last_hourly_reset is not None:

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -165,6 +165,7 @@ class PulseCollection:
         """Return timestamp of last update."""
         return self._pulses_timestamp
 
+    @property
     def pulse_counter_reset(self) -> bool:
         """Return a pulse_counter reset."""
         return self._cons_pulsecounter_reset or self._prod_pulsecounter_reset

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -767,33 +767,33 @@ class PulseCollection:
         if self._logs is None:
             return
 
-        log_time_stamp = self._logs[address][slot].timestamp
-        # Sync log_time_stamp with the device pulsecounter reset-time
+        log_timestamp = self._logs[address][slot].timestamp
+        # Sync log_timestamp with the device pulsecounter reset-time
         # This syncs the daily reset of energy counters with the corresponding device pulsecounter reset
         if (is_consumption := self._logs[address][slot].is_consumption):
             if self._cons_last_hourly_reset is not None:
-                log_time_stamp = log_time_stamp + timedelta(
+                log_timestamp = log_timestamp + timedelta(
                     minutes=self._cons_last_hourly_reset.minute,
                     seconds=self._cons_last_hourly_reset.second,
                     microseconds=self._cons_last_hourly_reset.microsecond,
                 )
         elif self._prod_last_hourly_reset is not None:
-            log_time_stamp = log_time_stamp + timedelta(
+            log_timestamp = log_timestamp + timedelta(
                 minutes=self._prod_last_hourly_reset.minute,
                 seconds=self._prod_last_hourly_reset.second,
                 microseconds=self._prod_last_hourly_reset.microsecond,
             )
 
         # Update log references
-        self._update_first_log_reference(address, slot, log_time_stamp, is_consumption)
-        self._update_last_log_reference(address, slot, log_time_stamp, is_consumption)
+        self._update_first_log_reference(address, slot, log_timestamp, is_consumption)
+        self._update_last_log_reference(address, slot, log_timestamp, is_consumption)
 
         if is_consumption:
-            self._update_first_consumption_log_reference(address, slot, log_time_stamp)
-            self._update_last_consumption_log_reference(address, slot, log_time_stamp)
+            self._update_first_consumption_log_reference(address, slot, log_timestamp)
+            self._update_last_consumption_log_reference(address, slot, log_timestamp)
         elif self._log_production:
-            self._update_first_production_log_reference(address, slot, log_time_stamp)
-            self._update_last_production_log_reference(address, slot, log_time_stamp)
+            self._update_first_production_log_reference(address, slot, log_timestamp)
+            self._update_last_production_log_reference(address, slot, log_timestamp)
 
     @property
     def log_addresses_missing(self) -> list[int] | None:

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -306,7 +306,7 @@ class PulseCollection:
                 "update_pulse_counter | production pulses reset | hourly_reset_time=%s",
                 self._last_hourly_reset,
             )
-        # No rollover based on time, check rollover based on counter reset
+        # No rollover based on time, set rollover based on counter reset
         # Required for special cases like nodes which have been powered off for several days
         if not (self._rollover_consumption or self._rollover_production):
             if self._cons_pulsecounter_reset:

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -67,7 +67,6 @@ class PulseCollection:
         self._last_empty_log_address: int | None = None
         self._last_empty_log_slot: int | None = None
 
-        self._last_hourly_reset: datetime | None = None
         self._last_log_consumption_timestamp: datetime | None = None
         self._last_log_consumption_address: int | None = None
         self._last_log_consumption_slot: int | None = None
@@ -844,7 +843,7 @@ class PulseCollection:
         # return missing logs in range first
         if len(missing) > 0:
             _LOGGER.debug(
-            "_logs_missing | %s | missing in range=%s", self._mac, missing
+                "_logs_missing | %s | missing in range=%s", self._mac, missing
             )
             return missing
 
@@ -931,7 +930,7 @@ class PulseCollection:
             if self._log_interval_consumption == 0:
                 pass
 
-        if not self._log_production:  #False
+        if not self._log_production:
             expected_timestamp = (
                 self._logs[address][slot].timestamp - calc_interval_cons
             )
@@ -989,7 +988,7 @@ class PulseCollection:
             # Use consumption interval
             calc_interval_cons = timedelta(minutes=self._log_interval_consumption)
 
-        if not self._log_production:  # False
+        if not self._log_production:
             expected_timestamp = (
                 self._logs[address][slot].timestamp + calc_interval_cons
             )

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -381,7 +381,7 @@ class PulseCollection:
             )
             return True
 
-        if last_log_timestamp < self._pulses_timestamp < next_log_timestamp:
+        if last_log_timestamp <= self._pulses_timestamp <= next_log_timestamp:
             _LOGGER.debug(
                 "_update_rollover | %s | reset %s rollover",
                 self._mac,

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -291,10 +291,9 @@ class PulseCollection:
             and self._pulses_consumption > pulses_consumed
         ):
             self._cons_pulsecounter_reset = True
-            _LOGGER.debug("update_pulse_counter | consumption pulses reset")
             self._last_hourly_reset = timestamp
             _LOGGER.debug(
-                "update_pulse_counter | hourly_reset_time=%s",
+                "update_pulse_counter | consumption pulses reset | hourly_reset_time=%s",
                 self._last_hourly_reset,
             )
 
@@ -303,7 +302,10 @@ class PulseCollection:
             and self._pulses_production < pulses_produced 
         ):
             self._prod_pulsecounter_reset = True
-
+            _LOGGER.debug(
+                "update_pulse_counter | production pulses reset | hourly_reset_time=%s",
+                self._last_hourly_reset,
+            )
         # No rollover based on time, check rollover based on counter reset
         # Required for special cases like nodes which have been powered off for several days
         if not (self._rollover_consumption or self._rollover_production):

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -107,13 +107,8 @@ class PulseCollection:
         return counter
 
     @property
-    def last_hourly_reset(self) -> datetime | None:
-        """Consumption and production last hourly reset."""
-        return self._last_hourly_reset
-
-    @property
     def hourly_reset_time(self) -> datetime | None:
-        """Provide the device hourly pulse reset time, using in testing.""" 
+        """Provide the device hourly pulse reset time.""" 
         if (timestamp := self._last_hourly_reset) is not None:
             return timestamp
         return None

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -841,12 +841,11 @@ class PulseCollection:
             if self._logs[address][slot].timestamp <= from_timestamp:
                 break
 
-        _LOGGER.debug(
-           "_logs_missing | %s | missing in range=%s", self._mac, missing
-        )
-
         # return missing logs in range first
         if len(missing) > 0:
+            _LOGGER.debug(
+            "_logs_missing | %s | missing in range=%s", self._mac, missing
+            )
             return missing
 
         if first_address not in self._logs:
@@ -880,11 +879,6 @@ class PulseCollection:
         calculated_timestamp = self._logs[first_address][
             first_slot
         ].timestamp - timedelta(minutes=log_interval)
-        _LOGGER.debug(
-                "_logs_missing | %s | calculated timestamp=%s",
-                self._mac,
-                calculated_timestamp,
-        )
         while from_timestamp < calculated_timestamp:
             if (
                 address == self._first_empty_log_address

--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -165,6 +165,10 @@ class PulseCollection:
         """Return timestamp of last update."""
         return self._pulses_timestamp
 
+    def pulse_counter_reset(self) -> bool:
+        """Return a pulse_counter reset."""
+        return self._cons_pulsecounter_reset or self._prod_pulsecounter_reset
+
     def collected_pulses(
         self, from_timestamp: datetime, is_consumption: bool
     ) -> tuple[int | None, datetime | None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a82"
+version         = "v0.40.0a83"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a88"
+version         = "v0.40.0a89"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a84"
+version         = "v0.40.0a85"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a78"
+version         = "v0.40.0a79"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a86"
+version         = "v0.40.0a87"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a80"
+version         = "v0.40.0a81"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a79"
+version         = "v0.40.0a80"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a83"
+version         = "v0.40.0a84"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a76"
+version         = "v0.40.0a77"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a73"
+version         = "v0.40.0a74"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a75"
+version         = "v0.40.0a76"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a85"
+version         = "v0.40.0a86"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a77"
+version         = "v0.40.0a78"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a81"
+version         = "v0.40.0a82"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a87"
+version         = "v0.40.0a88"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a72"
+version         = "v0.40.0a73"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "v0.40.0a74"
+version         = "v0.40.0a75"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1148,7 +1148,7 @@ class TestStick:
         ) == (145 + 2222 + 3333, pulse_update_5)
         pulse_update_6 = fixed_this_hour + td(hours=2, seconds=10)
         tst_consumption.update_pulse_counter(321, 0, pulse_update_6)
-        assert tst_consumption.log_rollover
+        assert not tst_consumption.log_rollover
         assert tst_consumption.collected_pulses(
             fixed_this_hour, is_consumption=True
         ) == (2222 + 3333 + 321, pulse_update_6)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1121,7 +1121,6 @@ class TestStick:
         pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1, seconds=3)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
-        assert tst_consumption.hourly_reset_time == pulse_update_4
         test_timestamp = fixed_this_hour + td(hours=1, minutes=1, seconds=4)
         assert tst_consumption.collected_pulses(
             test_timestamp, is_consumption=True

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1122,11 +1122,11 @@ class TestStick:
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
         assert tst_consumption.hourly_reset_time == pulse_update_4
-        test_timestamp = fixed_this_hour + td(hours=1, minutes=1, seconds=5)
+        test_timestamp = fixed_this_hour + td(hours=1, minutes=1, seconds=4)
         assert tst_consumption.collected_pulses(
             test_timestamp, is_consumption=True
         ) == (45, pulse_update_4)
-        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
+        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1, minutes=1, seconds=5)), 2222)
         assert tst_consumption.log_rollover
         # Test collection of the last full hour
         assert tst_consumption.collected_pulses(


### PR DESCRIPTION
All changes:
- Add support for devices with production enabled (setting Deliver energy / Levert energie in Source required).
- Fix rollover behaviour (cumulative sensor-rollover is based on the device-rollover).
  - Hourly rollover is based on device pulse counter reset
  - Daily rollover synced with device hourly-rollover
- Add/improve logger messages.
- Fix missing await-message in HA (https://github.com/plugwise/python-plugwise-usb/pull/218/commits/a24cb79f3a5ba6124aa84d9b7699ec6f1c4cf31e, https://github.com/plugwise/python-plugwise-usb/pull/218/commits/e43e97edc1d5d8d8006e7457b51d2509f450bc8c).
- Small improvements, add a missing line, add guarding.
- Adapt/improve testing