### PR TITLE
Improve async testing

### DIFF
--- a/plugwise_usb/nodes/helpers/pulses.py
+++ b/plugwise_usb/nodes/helpers/pulses.py
@@ -468,7 +468,7 @@ class PulseCollection:
             return False
 
         # Drop useless log records when we have at least 4 logs
-        if self.collected_logs > 4 and log_record.timestamp < (
+        if self.collected_logs > 4 and log_record.timestamp <= (
             datetime.now(tz=UTC) - timedelta(hours=MAX_LOG_HOURS)
         ):
             return False

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1124,14 +1124,19 @@ class TestStick:
         assert tst_consumption.collected_pulses(
             fixed_this_hour - td(hours=24), is_consumption=True
         ) == (2500 + 23861, pulse_update_3)
-        pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1, seconds=3)
+        pulse_update_4 = fixed_this_hour + td(hours=0, minutes=1)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
         assert tst_consumption.hourly_reset_time == pulse_update_4
         test_timestamp = fixed_this_hour + td(hours=1)
+        # Collected pulses last hour:
         assert tst_consumption.collected_pulses(
-            test_timestamp, is_consumption=True
+            fixed_this_hour, is_consumption=True
         ) == (45, pulse_update_4)
+        # Collected pulses last day:
+        assert tst_consumption.collected_pulses(
+            fixed_this_hour - td(hours=24), is_consumption=True
+        ) == (2500 + 23861, pulse_update_3)
         tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
         assert not tst_consumption.log_rollover
         # Test collection of the last full hour

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1123,7 +1123,7 @@ class TestStick:
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
             fixed_this_hour - td(hours=24), is_consumption=True
-        ) == (2500 + 1111 + 1000 + 750, pulse_update_3)
+        ) == (2500 + 23861, pulse_update_3)
         pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1, seconds=3)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1135,32 +1135,34 @@ class TestStick:
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
             test_timestamp - td(hours=24), is_consumption=True
-        ) == (45 + 2500 + 20361, pulse_update_4)
-        # tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
-        # assert not tst_consumption.log_rollover
-        ## Test collection of the last full hour
-        # assert tst_consumption.collected_pulses(
-        #     fixed_this_hour, is_consumption=True
-        # ) == (45 + 2222, pulse_update_4)
-        # pulse_update_5 = fixed_this_hour + td(hours=1, minutes=1, seconds=18)
-        # tst_consumption.update_pulse_counter(145, 0, pulse_update_5)
-        ## Test collection of the last new hour
-        # assert tst_consumption.collected_pulses(
-        #     test_timestamp, is_consumption=True
-        # ) == (145, pulse_update_5)
+        ) == (45 + 23861, pulse_update_4)  
+        # pulse-count of 2500 is ignored, the code does not export this incorrect value
+
+        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
+        assert not tst_consumption.log_rollover
+        # Test collection of the last full hour
+        assert tst_consumption.collected_pulses(
+            fixed_this_hour, is_consumption=True
+        ) == (45 + 2222, pulse_update_4)
+        pulse_update_5 = fixed_this_hour + td(hours=1, minutes=1, seconds=18)
+        tst_consumption.update_pulse_counter(145, 0, pulse_update_5)
+        # Test collection of the last new hour
+        assert tst_consumption.collected_pulses(
+            test_timestamp, is_consumption=True
+        ) == (145, pulse_update_5)
 
         # Test log rollover by updating log first before updating pulses
-        tst_consumption.add_log(100, 3, (fixed_this_hour + td(hours=2)), 3333)
-        assert tst_consumption.log_rollover
-        assert tst_consumption.collected_pulses(
-            fixed_this_hour, is_consumption=True
-        ) == (145 + 2222 + 3333, pulse_update_5)
-        pulse_update_6 = fixed_this_hour + td(hours=2, seconds=10)
-        tst_consumption.update_pulse_counter(321, 0, pulse_update_6)
-        assert not tst_consumption.log_rollover
-        assert tst_consumption.collected_pulses(
-            fixed_this_hour, is_consumption=True
-        ) == (2222 + 3333 + 321, pulse_update_6)
+        # tst_consumption.add_log(100, 3, (fixed_this_hour + td(hours=2)), 3333)
+        # assert tst_consumption.log_rollover
+        # assert tst_consumption.collected_pulses(
+        #     fixed_this_hour, is_consumption=True
+        # ) == (145 + 2222 + 3333, pulse_update_5)
+        # pulse_update_6 = fixed_this_hour + td(hours=2, seconds=10)
+        # tst_consumption.update_pulse_counter(321, 0, pulse_update_6)
+        # assert not tst_consumption.log_rollover
+        # assert tst_consumption.collected_pulses(
+        #     fixed_this_hour, is_consumption=True
+        # ) == (2222 + 3333 + 321, pulse_update_6)
 
     @freeze_time(dt.now())
     def test_pulse_collection_consumption_empty(

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -939,7 +939,7 @@ class TestStick:
         )
         await stick.disconnect()
 
-    @freeze_time("2025-04-04 00:00:00", tz_offset=0)
+    @freeze_time("2025-04-04 00:00:00")
     def test_pulse_collection_consumption(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -948,7 +948,7 @@ class TestStick:
 
         # fixed_timestamp_utc = dt.now(UTC)
         # fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
-        fixed_this_hour = dt.now()
+        fixed_this_hour = dt.now(UTC)
 
         # Test consumption logs
         tst_consumption = pw_energy_pulses.PulseCollection(mac="0098765432101234")

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -939,7 +939,7 @@ class TestStick:
         )
         await stick.disconnect()
 
-    @freeze_time("2025-04-04 00:00:00")
+    @freeze_time("2025-04-03 23:00:00")
     def test_pulse_collection_consumption(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1152,17 +1152,17 @@ class TestStick:
         ) == (145, pulse_update_5)
 
         # Test log rollover by updating log first before updating pulses
-        # tst_consumption.add_log(100, 3, (fixed_this_hour + td(hours=2)), 3333)
-        # assert tst_consumption.log_rollover
-        # assert tst_consumption.collected_pulses(
-        #     fixed_this_hour, is_consumption=True
-        # ) == (145 + 2222 + 3333, pulse_update_5)
-        # pulse_update_6 = fixed_this_hour + td(hours=2, seconds=10)
-        # tst_consumption.update_pulse_counter(321, 0, pulse_update_6)
-        # assert not tst_consumption.log_rollover
-        # assert tst_consumption.collected_pulses(
-        #     fixed_this_hour, is_consumption=True
-        # ) == (2222 + 3333 + 321, pulse_update_6)
+        tst_consumption.add_log(100, 3, (fixed_this_hour + td(hours=2)), 3333)
+        assert tst_consumption.log_rollover
+        assert tst_consumption.collected_pulses(
+            fixed_this_hour, is_consumption=True
+        ) == (145 + 2222 + 3333, pulse_update_5)
+        pulse_update_6 = fixed_this_hour + td(hours=2, seconds=10)
+        tst_consumption.update_pulse_counter(321, 0, pulse_update_6)
+        assert not tst_consumption.log_rollover
+        assert tst_consumption.collected_pulses(
+            fixed_this_hour, is_consumption=True
+        ) == (2222 + 3333 + 321, pulse_update_6)
 
     @freeze_time(dt.now())
     def test_pulse_collection_consumption_empty(

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1127,7 +1127,7 @@ class TestStick:
             test_timestamp, is_consumption=True
         ) == (45, pulse_update_4)
         tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
-        assert tst_consumption.log_rollover
+        assert not tst_consumption.log_rollover
         # Test collection of the last full hour
         assert tst_consumption.collected_pulses(
             fixed_this_hour, is_consumption=True

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1128,7 +1128,6 @@ class TestStick:
         pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
-        assert tst_consumption.hourly_reset_time == pulse_update_4
         # Collected pulses last hour:
         assert tst_consumption.collected_pulses(
             test_timestamp, is_consumption=True

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1116,8 +1116,13 @@ class TestStick:
         pulse_update_3 = fixed_this_hour + td(hours=0, minutes=0, seconds=30)
         tst_consumption.update_pulse_counter(2500, 0, pulse_update_3)
         assert not tst_consumption.log_rollover
+        # Collected pulses last hour:
         assert tst_consumption.collected_pulses(
-            test_timestamp, is_consumption=True
+            fixed_this_hour, is_consumption=True
+        ) == (2500, pulse_update_3)
+        # Collected pulses last day:
+        assert tst_consumption.collected_pulses(
+            fixed_this_hour - td(hours=24), is_consumption=True
         ) == (2500 + 1111 + 1000 + 750, pulse_update_3)
         pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1, seconds=3)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1135,7 +1135,7 @@ class TestStick:
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
             test_timestamp - td(hours=24), is_consumption=True
-        ) == (45 + 23861, pulse_update_4)  
+        ) == (45 + 22861, pulse_update_4)  
         # pulse-count of 2500 is ignored, the code does not export this incorrect value
 
         tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -939,7 +939,7 @@ class TestStick:
         )
         await stick.disconnect()
 
-    @freeze_time(dt.now())
+    @freeze_time("2025-04-04 00:00:00", tz_offset=-2)
     def test_pulse_collection_consumption(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -948,7 +948,7 @@ class TestStick:
 
         # fixed_timestamp_utc = dt.now(UTC)
         # fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
-        fixed_this_hour = freeze_time("2025-04-04 00:00:00")
+        fixed_this_hour = dt.now(UTC)
 
         # Test consumption logs
         tst_consumption = pw_energy_pulses.PulseCollection(mac="0098765432101234")

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1126,7 +1126,7 @@ class TestStick:
         assert tst_consumption.collected_pulses(
             test_timestamp, is_consumption=True
         ) == (45, pulse_update_4)
-        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1, minutes=1, seconds=5)), 2222)
+        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
         assert tst_consumption.log_rollover
         # Test collection of the last full hour
         assert tst_consumption.collected_pulses(

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -945,9 +945,6 @@ class TestStick:
     ) -> None:
         """Testing pulse collection class."""
         monkeypatch.setattr(pw_energy_pulses, "MAX_LOG_HOURS", 24)
-
-        # fixed_timestamp_utc = dt.now(UTC)
-        # fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
         fixed_this_hour = dt.now(UTC)
 
         # Test consumption logs
@@ -1086,7 +1083,6 @@ class TestStick:
 
         assert not tst_consumption.log_rollover
         # add missing logs
-        test_timestamp = fixed_this_hour - td(hours=3)
         tst_consumption.add_log(99, 2, (fixed_this_hour - td(hours=3)), 1000)
         tst_consumption.add_log(99, 1, (fixed_this_hour - td(hours=4)), 1000)
         tst_consumption.add_log(98, 4, (fixed_this_hour - td(hours=5)), 1000)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -939,7 +939,7 @@ class TestStick:
         )
         await stick.disconnect()
 
-    @freeze_time("2025-04-04 00:00:00", tz_offset=-2)
+    @freeze_time("2025-04-04 00:00:00", tz_offset=0)
     def test_pulse_collection_consumption(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -948,7 +948,7 @@ class TestStick:
 
         # fixed_timestamp_utc = dt.now(UTC)
         # fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
-        fixed_this_hour = dt.now(UTC)
+        fixed_this_hour = dt.now()
 
         # Test consumption logs
         tst_consumption = pw_energy_pulses.PulseCollection(mac="0098765432101234")

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1135,7 +1135,7 @@ class TestStick:
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
             test_timestamp - td(hours=24), is_consumption=True
-        ) == (45 + 2500 + 23861, pulse_update_4)
+        ) == (45 + 2500 + 20361, pulse_update_4)
         # tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
         # assert not tst_consumption.log_rollover
         ## Test collection of the last full hour

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1113,42 +1113,42 @@ class TestStick:
 
 
         # Test rollover by updating pulses before log record
-        pulse_update_3 = fixed_this_hour + td(hours=0, minutes=0, seconds=30)
+        pulse_update_3 = fixed_this_hour + td(hours=1, minutes=0, seconds=30)
+        test_timestamp = fixed_this_hour + td(hours=1)
         tst_consumption.update_pulse_counter(2500, 0, pulse_update_3)
-        assert not tst_consumption.log_rollover
+        assert tst_consumption.log_rollover
         # Collected pulses last hour:
         assert tst_consumption.collected_pulses(
-            fixed_this_hour, is_consumption=True
+            test_timestamp, is_consumption=True
         ) == (2500, pulse_update_3)
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
-            fixed_this_hour - td(hours=24), is_consumption=True
-        ) == (2500 + 23861, pulse_update_3)
-        pulse_update_4 = fixed_this_hour + td(hours=0, minutes=1)
+            test_timestamp - td(hours=24), is_consumption=True
+        ) == (2500 + 22861, pulse_update_3)
+        pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
         assert tst_consumption.hourly_reset_time == pulse_update_4
-        test_timestamp = fixed_this_hour + td(hours=1)
         # Collected pulses last hour:
         assert tst_consumption.collected_pulses(
-            fixed_this_hour, is_consumption=True
+            test_timestamp, is_consumption=True
         ) == (45, pulse_update_4)
         # Collected pulses last day:
         assert tst_consumption.collected_pulses(
-            fixed_this_hour - td(hours=24), is_consumption=True
-        ) == (2500 + 23861, pulse_update_3)
-        tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
-        assert not tst_consumption.log_rollover
-        # Test collection of the last full hour
-        assert tst_consumption.collected_pulses(
-            fixed_this_hour, is_consumption=True
-        ) == (45 + 2222, pulse_update_4)
-        pulse_update_5 = fixed_this_hour + td(hours=1, minutes=1, seconds=18)
-        tst_consumption.update_pulse_counter(145, 0, pulse_update_5)
-        # Test collection of the last new hour
-        assert tst_consumption.collected_pulses(
-            test_timestamp, is_consumption=True
-        ) == (145, pulse_update_5)
+            test_timestamp - td(hours=24), is_consumption=True
+        ) == (45 + 2500 + 23861, pulse_update_4)
+        # tst_consumption.add_log(100, 2, (fixed_this_hour + td(hours=1)), 2222)
+        # assert not tst_consumption.log_rollover
+        ## Test collection of the last full hour
+        # assert tst_consumption.collected_pulses(
+        #     fixed_this_hour, is_consumption=True
+        # ) == (45 + 2222, pulse_update_4)
+        # pulse_update_5 = fixed_this_hour + td(hours=1, minutes=1, seconds=18)
+        # tst_consumption.update_pulse_counter(145, 0, pulse_update_5)
+        ## Test collection of the last new hour
+        # assert tst_consumption.collected_pulses(
+        #     test_timestamp, is_consumption=True
+        # ) == (145, pulse_update_5)
 
         # Test log rollover by updating log first before updating pulses
         tst_consumption.add_log(100, 3, (fixed_this_hour + td(hours=2)), 3333)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -939,7 +939,7 @@ class TestStick:
         )
         await stick.disconnect()
 
-    @freeze_time("2025-04-03 23:00:00")
+    @freeze_time("2025-04-03 22:00:00")
     def test_pulse_collection_consumption(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1122,7 +1122,8 @@ class TestStick:
         pulse_update_4 = fixed_this_hour + td(hours=1, minutes=1, seconds=3)
         tst_consumption.update_pulse_counter(45, 0, pulse_update_4)
         assert tst_consumption.log_rollover
-        test_timestamp = fixed_this_hour + td(hours=1, minutes=1, seconds=4)
+        assert tst_consumption.hourly_reset_time == pulse_update_4
+        test_timestamp = fixed_this_hour + td(hours=1)
         assert tst_consumption.collected_pulses(
             test_timestamp, is_consumption=True
         ) == (45, pulse_update_4)
@@ -1133,11 +1134,10 @@ class TestStick:
             fixed_this_hour, is_consumption=True
         ) == (45 + 2222, pulse_update_4)
         pulse_update_5 = fixed_this_hour + td(hours=1, minutes=1, seconds=18)
-        test_timestamp_2 = fixed_this_hour + td(hours=1, minutes=1, seconds=20)
         tst_consumption.update_pulse_counter(145, 0, pulse_update_5)
         # Test collection of the last new hour
         assert tst_consumption.collected_pulses(
-            test_timestamp_2, is_consumption=True
+            test_timestamp, is_consumption=True
         ) == (145, pulse_update_5)
 
         # Test log rollover by updating log first before updating pulses

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -946,8 +946,9 @@ class TestStick:
         """Testing pulse collection class."""
         monkeypatch.setattr(pw_energy_pulses, "MAX_LOG_HOURS", 24)
 
-        fixed_timestamp_utc = dt.now(UTC)
-        fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
+        # fixed_timestamp_utc = dt.now(UTC)
+        # fixed_this_hour = fixed_timestamp_utc.replace(minute=0, second=0, microsecond=0)
+        fixed_this_hour = freeze_time("2025-04-04 00:00:00")
 
         # Test consumption logs
         tst_consumption = pw_energy_pulses.PulseCollection(mac="0098765432101234")


### PR DESCRIPTION
Change test case `test_pulse_collection_consumption` to testing at the same, frozen time, this will result in predicable test result for pulses collected over 24 hrs.

This change also resulted in finding a small bug in the actual code.