### PR TITLE
Let PlugwiseCirclePlus class load NodeFeature.CIRCLE too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v0.44.4
+## v0.44.5 - 2025-06-22
+
+- PR [274](https://github.com/plugwise/python-plugwise-usb/pull/274): Make the energy-reset function available to Plus devices
+
+## v0.44.4 - 2025-06-21
 
 - PR [#255](https://github.com/plugwise/python-plugwise-usb/pull/255): Improve enery-logs reset process, enable use of a button in Plugwise_usb beta
 - PR [#261](https://github.com/plugwise/python-plugwise-usb/pull/261): Sense: bugfix parsing of humidity value as an unsigned int

--- a/plugwise_usb/nodes/circle_plus.py
+++ b/plugwise_usb/nodes/circle_plus.py
@@ -19,6 +19,15 @@ from .helpers.firmware import CIRCLE_PLUS_FIRMWARE_SUPPORT
 
 _LOGGER = logging.getLogger(__name__)
 
+FEATURES_CIRCLE_PLUS = (
+    NodeFeature.RELAY,
+    NodeFeature.RELAY_INIT,
+    NodeFeature.RELAY_LOCK,
+    NodeFeature.ENERGY,
+    NodeFeature.POWER,
+    NodeFeature.CIRCLE,
+    NodeFeature.CIRCLEPLUS,
+)
 
 class PlugwiseCirclePlus(PlugwiseCircle):
     """Plugwise Circle+ node."""
@@ -31,21 +40,11 @@ class PlugwiseCirclePlus(PlugwiseCircle):
             _LOGGER.debug("Loading Circle node %s from cache", self._node_info.mac)
             if await self._load_from_cache():
                 self._loaded = True
-                self._setup_protocol(
-                    CIRCLE_PLUS_FIRMWARE_SUPPORT,
-                    (
-                        NodeFeature.RELAY,
-                        NodeFeature.RELAY_INIT,
-                        NodeFeature.RELAY_LOCK,
-                        NodeFeature.ENERGY,
-                        NodeFeature.POWER,
-                        NodeFeature.CIRCLE,
-                        NodeFeature.CIRCLEPLUS,
-                    ),
-                )
+                self._setup_protocol(CIRCLE_PLUS_FIRMWARE_SUPPORT, FEATURES_CIRCLE_PLUS)
                 if await self.initialize():
                     await self._loaded_callback(NodeEvent.LOADED, self.mac)
                     return True
+
             _LOGGER.info(
                 "Loading Circle+ node %s from cache failed",
                 self._node_info.mac,
@@ -68,21 +67,12 @@ class PlugwiseCirclePlus(PlugwiseCircle):
                 self._node_info.mac,
             )
             return False
+
         self._loaded = True
-        self._setup_protocol(
-            CIRCLE_PLUS_FIRMWARE_SUPPORT,
-            (
-                NodeFeature.RELAY,
-                NodeFeature.RELAY_INIT,
-                NodeFeature.RELAY_LOCK,
-                NodeFeature.ENERGY,
-                NodeFeature.POWER,
-                NodeFeature.CIRCLE,
-                NodeFeature.CIRCLEPLUS,
-            ),
-        )
+        self._setup_protocol(CIRCLE_PLUS_FIRMWARE_SUPPORT, FEATURES_CIRCLE_PLUS)
         if not await self.initialize():
             return False
+
         await self._loaded_callback(NodeEvent.LOADED, self.mac)
         return True
 

--- a/plugwise_usb/nodes/circle_plus.py
+++ b/plugwise_usb/nodes/circle_plus.py
@@ -39,6 +39,7 @@ class PlugwiseCirclePlus(PlugwiseCircle):
                         NodeFeature.RELAY_LOCK,
                         NodeFeature.ENERGY,
                         NodeFeature.POWER,
+                        NodeFeature.CIRCLE,
                         NodeFeature.CIRCLEPLUS,
                     ),
                 )
@@ -76,6 +77,7 @@ class PlugwiseCirclePlus(PlugwiseCircle):
                 NodeFeature.RELAY_LOCK,
                 NodeFeature.ENERGY,
                 NodeFeature.POWER,
+                NodeFeature.CIRCLE,
                 NodeFeature.CIRCLEPLUS,
             ),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.4"
+version         = "0.44.5a0"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.5a0"
+version         = "0.44.5"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -2484,6 +2484,7 @@ class TestStick:
         assert sorted(state[pw_api.NodeFeature.INFO].features) == sorted(
             (
                 pw_api.NodeFeature.AVAILABLE,
+                pw_api.NodeFeature.CIRCLE,
                 pw_api.NodeFeature.CIRCLEPLUS,
                 pw_api.NodeFeature.INFO,
                 pw_api.NodeFeature.PING,


### PR DESCRIPTION
This makes the reset energy collection function available to the + devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the CIRCLE feature to relevant nodes.
- **Tests**
  - Updated tests to include verification for the new CIRCLE feature.
- **Chores**
  - Bumped version number to 0.44.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->