### PR TITLE
keep repeating discover_nodes until all registered nodes are online

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ fixtures/*
 tmp
 .cache
 appdata_folder
+mock_folder_that_exists/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.44.6 - 2025-07-06
+
+- PR [279](https://github.com/plugwise/python-plugwise-usb/pull/279): Improve registry cache and node load behaviour
+
 ## v0.44.5 - 2025-06-22
 
 - PR [274](https://github.com/plugwise/python-plugwise-usb/pull/274): Make the energy-reset function available to Plus devices

--- a/plugwise_usb/constants.py
+++ b/plugwise_usb/constants.py
@@ -41,7 +41,8 @@ STICK_TIME_OUT: Final = 11
 NODE_TIME_OUT: Final = 15
 
 # Retry delay discover nodes
-NODE_DISCOVER_INTERVAL = 60
+NODE_RETRY_DISCOVER_INTERVAL = 60
+NODE_RETRY_LOAD_INTERVAL = 60
 
 MAX_RETRIES: Final = 3
 SUPPRESS_INITIALIZATION_WARNINGS: Final = 10  # Minutes to suppress (expected) communication warning messages after initialization

--- a/plugwise_usb/constants.py
+++ b/plugwise_usb/constants.py
@@ -40,6 +40,9 @@ STICK_TIME_OUT: Final = 11
 # In bigger networks a response from a Node could take up a while, so lets use 15 seconds.
 NODE_TIME_OUT: Final = 15
 
+# Retry delay discover nodes
+NODE_DISCOVER_INTERVAL = 60
+
 MAX_RETRIES: Final = 3
 SUPPRESS_INITIALIZATION_WARNINGS: Final = 10  # Minutes to suppress (expected) communication warning messages after initialization
 

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -553,6 +553,18 @@ class StickNetwork:
         for task in self._discover_sed_tasks.values():
             if not task.done():
                 task.cancel()
+        if (
+            hasattr(self, "_load_stragglers_task")
+            and self._load_stragglers_task
+            and not self._load_stragglers_task.done()
+        ):
+            self._load_stragglers_task.cancel()
+        if (
+            hasattr(self, "_discover_stragglers_task")
+            and self._discover_stragglers_task
+            and not self._discover_stragglers_task.done()
+        ):
+            self._discover_stragglers_task.cancel()
         self._is_running = False
         self._unsubscribe_to_protocol_events()
         await self._unload_discovered_nodes()

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -540,10 +540,9 @@ class StickNetwork:
         if not self._is_running:
             await self.start()
         await self._discover_registered_nodes()
-        if load:
-            if not await self._load_discovered_nodes():
-                self._load_stragglers_task = create_task(self._load_stragglers())
-                return False
+        if load and not await self._load_discovered_nodes():
+            self._load_stragglers_task = create_task(self._load_stragglers())
+            return False
 
         return True
 
@@ -568,7 +567,7 @@ class StickNetwork:
         self._is_running = False
         self._unsubscribe_to_protocol_events()
         await self._unload_discovered_nodes()
-        await self._register.stop()
+        self._register.stop()
         _LOGGER.debug("Stopping finished")
 
     # endregion

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -484,7 +484,7 @@ class StickNetwork:
             return True
         return False
 
-    async def _discover_stragglers(self) -> None:
+    async def _load_stragglers(self) -> None:
         """Retry failed load operation."""
         await sleep(60)
         while not self._load_discovered_nodes():

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -69,6 +69,6 @@ class NetworkRegistrationCache(PlugwiseCache):
         self._nodetypes[mac] = node_type
         await self.save_cache()
 
-    def get_nodetype(self, mac: str) -> NodeType:
+    def get_nodetype(self, mac: str) -> NodeType | None:
         """Return NodeType from cache."""
         return self._nodetypes.get(mac)

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -20,7 +20,7 @@ class NetworkRegistrationCache(PlugwiseCache):
         self._nodetypes: dict[str, NodeType] = {}
 
     @property
-    def nodetypes(self) -> dict[str, NodeType | None]:
+    def nodetypes(self) -> dict[str, NodeType]:
         """Cached network information."""
         return self._nodetypes
 
@@ -68,3 +68,7 @@ class NetworkRegistrationCache(PlugwiseCache):
             )
         self._nodetypes[mac] = node_type
         await self.save_cache()
+
+    def get_nodetype(self, mac: str) -> NodeType:
+        """Return NodeType from cache."""
+        return self._nodetypes.get(mac)

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import logging
 
 from ..api import NodeType
-from ..constants import CACHE_DATA_SEPARATOR
 from ..helpers.cache import PlugwiseCache
 
 _LOGGER = logging.getLogger(__name__)
-_NETWORK_CACHE_FILE_NAME = "nodes.cache"
+_NETWORK_CACHE_FILE_NAME = "nodetype.cache"
 
 
 class NetworkRegistrationCache(PlugwiseCache):
@@ -18,68 +17,54 @@ class NetworkRegistrationCache(PlugwiseCache):
     def __init__(self, cache_root_dir: str = "") -> None:
         """Initialize NetworkCache class."""
         super().__init__(_NETWORK_CACHE_FILE_NAME, cache_root_dir)
-        self._registrations: dict[int, tuple[str, NodeType | None]] = {}
+        self._nodetypes: dict[str, NodeType] = {}
 
     @property
-    def registrations(self) -> dict[int, tuple[str, NodeType | None]]:
+    def nodetypes(self) -> dict[str, NodeType | None]:
         """Cached network information."""
-        return self._registrations
+        return self._nodetypes
 
     async def save_cache(self) -> None:
         """Save the node information to file."""
         cache_data_to_save: dict[str, str] = {}
-        for address in range(-1, 64, 1):
-            mac, node_type = self._registrations.get(address, ("", None))
-            if node_type is None:
-                node_value = ""
-            else:
-                node_value = str(node_type)
-            cache_data_to_save[str(address)] = (
-                f"{mac}{CACHE_DATA_SEPARATOR}{node_value}"
-            )
+        for mac, node_type in self._nodetypes.items():
+            node_value = str(node_type)
+            cache_data_to_save[mac] = node_value
+        _LOGGER.debug("Save NodeTypes %s", str(len(cache_data_to_save)))
         await self.write_cache(cache_data_to_save)
 
     async def clear_cache(self) -> None:
         """Clear current cache."""
-        self._registrations = {}
+        self._nodetypes = {}
         await self.delete_cache()
 
     async def restore_cache(self) -> None:
         """Load the previously stored information."""
         data: dict[str, str] = await self.read_cache()
-        self._registrations = {}
-        for _key, _data in data.items():
-            address = int(_key)
-            try:
-                if CACHE_DATA_SEPARATOR in _data:
-                    values = _data.split(CACHE_DATA_SEPARATOR)
-                else:
-                    # legacy data separator can by remove at next version
-                    values = _data.split(";")
-                mac = values[0]
-                node_type: NodeType | None = None
-                if values[1] != "":
-                    node_type = NodeType[values[1][9:]]
-                self._registrations[address] = (mac, node_type)
-                _LOGGER.debug(
-                    "Restore registry address %s with mac %s with node type %s",
-                    address,
-                    mac if mac != "" else "<empty>",
-                    str(node_type),
-                )
-            except (KeyError, IndexError):
-                _LOGGER.warning(
-                    "Skip invalid data '%s' in cache file '%s'",
-                    _data,
-                    self._cache_file,
-                )
+        self._nodetypes = {}
+        for mac, node_value in data.items():
+            node_type: NodeType | None = None
+            if len(node_value) >= 10:
+                node_type = NodeType[node_value[9:]]
+            if node_type is not None:
+                self._nodetypes[mac] = node_type
+            _LOGGER.debug(
+                "Restore NodeType for mac %s with node type %s",
+                mac,
+                str(node_type),
+            )
 
-    def update_registration(
-        self, address: int, mac: str, node_type: NodeType | None
-    ) -> None:
+    async def update_nodetypes(self, mac: str, node_type: NodeType | None) -> None:
         """Save node information in cache."""
-        if self._registrations.get(address) is not None:
-            _, current_node_type = self._registrations[address]
-            if current_node_type is not None and node_type is None:
+        if node_type is None:
+            return
+        if (current_node_type := self._nodetypes.get(mac)) is not None:
+            if current_node_type == node_type:
                 return
-        self._registrations[address] = (mac, node_type)
+            _LOGGER.warning(
+                "Cache contained mismatched NodeType %s replacing with %s",
+                str(current_node_type),
+                str(node_type),
+            )
+        self._nodetypes[mac] = node_type
+        await self.save_cache()

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -45,9 +45,14 @@ class NetworkRegistrationCache(PlugwiseCache):
         for mac, node_value in data.items():
             node_type: NodeType | None = None
             if len(node_value) >= 10:
-                node_type = NodeType[node_value[9:]]
-            if node_type is not None:
-                self._nodetypes[mac] = node_type
+                try:
+                    node_type = NodeType[node_value[9:]]
+                except KeyError:
+                    node_type = None
+            if node_type is None:
+                _LOGGER.warning("Invalid NodeType in cache: %s", node_value)
+                continue
+            self._nodetypes[mac] = node_type
             _LOGGER.debug(
                 "Restore NodeType for mac %s with node type %s",
                 mac,

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -163,9 +163,8 @@ class StickNetworkRegister:
                 node_type = self._network_cache.get_nodetype(mac)
 
         self._registry[address] = (mac, node_type)
-        if node_type is not None:
-            if self._network_cache is not None:
-                await self._network_cache.update_nodetypes(mac, node_type)
+        if node_type is not None and self._network_cache is not None:
+            await self._network_cache.update_nodetypes(mac, node_type)
 
     async def update_missing_registrations_full(self) -> None:
         """Full retrieval of all unknown network registrations from network controller."""

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -160,7 +160,7 @@ class StickNetworkRegister:
                 if current_type is not None:
                     return
             if self._network_cache is not None:
-                node_type = self._network_cache._nodetypes.get(mac)
+                node_type = self._network_cache.get_nodetype(mac)
 
         self._registry[address] = (mac, node_type)
         if node_type is not None:

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -278,6 +278,6 @@ class StickNetworkRegister:
             await self._network_cache.clear_cache()
             self._cache_restored = False
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """Unload the network registry."""
         self._stop_registration_task()

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -107,7 +107,6 @@ class StickNetworkRegister:
         """Initialize load the network registry."""
         if self._cache_enabled:
             await self.restore_network_cache()
-            await self.load_registry_from_cache()
         await self.update_missing_registrations_quick()
 
     async def restore_network_cache(self) -> None:
@@ -120,22 +119,6 @@ class StickNetworkRegister:
                 await self._network_cache.initialize_cache()
             await self._network_cache.restore_cache()
         self._cache_restored = True
-
-    async def load_registry_from_cache(self) -> None:
-        """Load network registry from cache."""
-        if self._network_cache is None:
-            _LOGGER.error(
-                "Unable to restore network registry because cache is not initialized"
-            )
-            return
-
-        if self._cache_restored:
-            return
-
-        for address, registration in self._network_cache.registrations.items():
-            mac, node_type = registration
-            if self._registry.get(address) is None:
-                self._registry[address] = (mac, node_type)
 
     async def retrieve_network_registration(
         self, address: int, retry: bool = True
@@ -167,17 +150,22 @@ class StickNetworkRegister:
             raise NodeError("Unable to return network controller details")
         return self.registry[-1]
 
-    def update_network_registration(
+    async def update_network_registration(
         self, address: int, mac: str, node_type: NodeType | None
     ) -> None:
         """Add a network registration."""
-        if self._registry.get(address) is not None:
-            _, current_type = self._registry[address]
-            if current_type is not None and node_type is None:
-                return
+        if node_type is None:
+            if self._registry.get(address) is not None:
+                _, current_type = self._registry[address]
+                if current_type is not None:
+                    return
+            if self._network_cache is not None:
+                node_type = self._network_cache._nodetypes.get(mac)
+
         self._registry[address] = (mac, node_type)
-        if self._network_cache is not None:
-            self._network_cache.update_registration(address, mac, node_type)
+        if node_type is not None:
+            if self._network_cache is not None:
+                await self._network_cache.update_nodetypes(mac, node_type)
 
     async def update_missing_registrations_full(self) -> None:
         """Full retrieval of all unknown network registrations from network controller."""
@@ -199,14 +187,10 @@ class StickNetworkRegister:
                     str(nextaddress),
                     "'empty'" if mac == "" else f"set to {mac}",
                 )
-                self.update_network_registration(nextaddress, mac, None)
+                await self.update_network_registration(nextaddress, mac, None)
             await sleep(10)
         _LOGGER.debug("Full network registration finished")
         self._scan_completed = True
-        if self._cache_enabled:
-            _LOGGER.debug("Full network registration finished, save to cache")
-            await self.save_registry_to_cache()
-            _LOGGER.debug("Full network registration finished, post")
         _LOGGER.info("Full network discovery completed")
         if self._full_scan_finished is not None:
             await self._full_scan_finished()
@@ -228,7 +212,7 @@ class StickNetworkRegister:
                     str(nextaddress),
                     "'empty'" if mac == "" else f"set to {mac}",
                 )
-                self.update_network_registration(nextaddress, mac, None)
+                await self.update_network_registration(nextaddress, mac, None)
             await sleep(0.1)
         if self._registration_task is None or self._registration_task.done():
             self._registration_task = create_task(
@@ -239,9 +223,9 @@ class StickNetworkRegister:
                 self._quick_scan_finished = None
             _LOGGER.info("Quick network registration discovery finished")
 
-    def update_node_registration(self, mac: str) -> int:
+    async def update_node_registration(self, mac: str) -> int:
         """Register (re)joined node to Plugwise network and return network address."""
-        self.update_network_registration(self._first_free_address, mac, None)
+        await self.update_network_registration(self._first_free_address, mac, None)
         self._first_free_address += 1
         return self._first_free_address - 1
 
@@ -250,22 +234,6 @@ class StickNetworkRegister:
         if self._registration_task is None:
             return
         self._registration_task.cancel()
-
-    async def save_registry_to_cache(self) -> None:
-        """Save network registry to cache."""
-        if self._network_cache is None:
-            _LOGGER.error(
-                "Unable to save network registry because cache is not initialized"
-            )
-            return
-        _LOGGER.debug(
-            "save_registry_to_cache starting for %s items", str(len(self._registry))
-        )
-        for address, registration in self._registry.items():
-            mac, node_type = registration
-            self._network_cache.update_registration(address, mac, node_type)
-        await self._network_cache.save_cache()
-        _LOGGER.debug("save_registry_to_cache finished")
 
     async def register_node(self, mac: str) -> None:
         """Register node to Plugwise network and return network address."""
@@ -303,7 +271,7 @@ class StickNetworkRegister:
                 + f" failed to unregister node '{mac}'"
             )
         if (address := self.network_address(mac)) is not None:
-            self.update_network_registration(address, mac, None)
+            await self.update_network_registration(address, mac, None)
 
     async def clear_register_cache(self) -> None:
         """Clear current cache."""
@@ -314,9 +282,3 @@ class StickNetworkRegister:
     async def stop(self) -> None:
         """Unload the network registry."""
         self._stop_registration_task()
-        if (
-            self._cache_enabled
-            and self._network_cache is not None
-            and self._network_cache.initialized
-        ):
-            await self.save_registry_to_cache()

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -884,48 +884,30 @@ class PlugwiseCircle(PlugwiseBaseNode):
             _LOGGER.debug("Loading Circle node %s from cache", self._mac_in_str)
             if await self._load_from_cache():
                 self._loaded = True
-                self._setup_protocol(
-                    CIRCLE_FIRMWARE_SUPPORT,
-                    (
-                        NodeFeature.CIRCLE,
-                        NodeFeature.RELAY,
-                        NodeFeature.RELAY_INIT,
-                        NodeFeature.RELAY_LOCK,
-                        NodeFeature.ENERGY,
-                        NodeFeature.POWER,
-                    ),
+        if not self._loaded:
+            _LOGGER.debug("Retrieving Info For Circle node %s", self._mac_in_str)
+
+            # Check if node is online
+            if not self._available and not await self.is_online():
+                _LOGGER.debug(
+                    "Failed to load Circle node %s because it is not online",
+                    self._mac_in_str,
                 )
-                if await self.initialize():
-                    await self._loaded_callback(NodeEvent.LOADED, self.mac)
-                    return True
+                return False
 
-            _LOGGER.debug(
-                "Loading Circle node %s from cache failed",
-                self._mac_in_str,
-            )
-        else:
-            _LOGGER.debug("Loading Circle node %s", self._mac_in_str)
+            # Get node info
+            if (
+                self.skip_update(self._node_info, 30)
+                and await self.node_info_update() is None
+            ):
+                _LOGGER.debug(
+                    "Failed to load Circle node %s because it is not responding to information request",
+                    self._mac_in_str,
+                )
+                return False
 
-        # Check if node is online
-        if not self._available and not await self.is_online():
-            _LOGGER.debug(
-                "Failed to load Circle node %s because it is not online",
-                self._mac_in_str,
-            )
-            return False
+            self._loaded = True
 
-        # Get node info
-        if (
-            self.skip_update(self._node_info, 30)
-            and await self.node_info_update() is None
-        ):
-            _LOGGER.debug(
-                "Failed to load Circle node %s because it is not responding to information request",
-                self._mac_in_str,
-            )
-            return False
-
-        self._loaded = True
         self._setup_protocol(
             CIRCLE_FIRMWARE_SUPPORT,
             (
@@ -937,10 +919,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 NodeFeature.POWER,
             ),
         )
-        if not await self.initialize():
-            return False
-
         await self._loaded_callback(NodeEvent.LOADED, self.mac)
+        await self.initialize()
         return True
 
     async def _load_from_cache(self) -> bool:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -896,10 +896,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 return False
 
             # Get node info
-            if (
-                self.skip_update(self._node_info, 30)
-                and await self.node_info_update() is None
-            ):
+            if await self.node_info_update() is None:
                 _LOGGER.debug(
                     "Failed to load Circle node %s because it is not responding to information request",
                     self._mac_in_str,

--- a/plugwise_usb/nodes/circle_plus.py
+++ b/plugwise_usb/nodes/circle_plus.py
@@ -29,6 +29,7 @@ FEATURES_CIRCLE_PLUS = (
     NodeFeature.CIRCLEPLUS,
 )
 
+
 class PlugwiseCirclePlus(PlugwiseCircle):
     """Plugwise Circle+ node."""
 

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -588,10 +588,9 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
         if await self.ping_update() is None:
             _LOGGER.debug("No response to ping for %s", self.mac)
             return False
-        if not self._initialized:
-            if not await self.initialize():
-                _LOGGER.debug("Node %s failed to initialize after ping", self.mac)
-                return False
+        if not self._initialized and self._loaded and not await self.initialize():
+            _LOGGER.debug("Node %s failed to initialize after ping", self.mac)
+            return False
         return True
 
     async def ping_update(

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -229,6 +229,11 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
         return self._node_info
 
     @property
+    def initialized(self) -> bool:
+        """Node is Initialized."""
+        return self._initialized
+
+    @property
     def mac(self) -> str:
         """Zigbee mac address of node."""
         return self._mac_in_str
@@ -583,6 +588,8 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
         if await self.ping_update() is None:
             _LOGGER.debug("No response to ping for %s", self.mac)
             return False
+        if not self._initialized:
+            await self.initialize()
         return True
 
     async def ping_update(

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -589,7 +589,9 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
             _LOGGER.debug("No response to ping for %s", self.mac)
             return False
         if not self._initialized:
-            await self.initialize()
+            if not await self.initialize():
+                _LOGGER.debug("Node %s failed to initialize after ping", self.mac)
+                return False
         return True
 
     async def ping_update(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.5"
+version         = "0.44.6"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -207,17 +207,15 @@ class MockOsPath:
 
     async def exists(self, file_or_path: str) -> bool:  # noqa:  PLR0911
         """Exists folder."""
-        if file_or_path == "mock_folder_that_exists":
-            return True
-        if file_or_path == "mock_folder_that_exists/nodetype.cache":
-            return True
-        if file_or_path == "mock_folder_that_exists\\nodetype.cache":
-            return True
-        if file_or_path == "mock_folder_that_exists/0123456789ABCDEF.cache":
-            return True
-        if file_or_path == "mock_folder_that_exists\\0123456789ABCDEF.cache":
-            return True
-        if file_or_path == "mock_folder_that_exists\\file_that_exists.ext":
+        test_exists = [
+            "mock_folder_that_exists",
+            "mock_folder_that_exists/nodetype.cache",
+            "mock_folder_that_exists\\nodetype.cache",
+            "mock_folder_that_exists/0123456789ABCDEF.cache",
+            "mock_folder_that_exists\\0123456789ABCDEF.cache",
+            "mock_folder_that_exists\\file_that_exists.ext",
+        ]
+        if file_or_path in test_exists:
             return True
         return file_or_path == "mock_folder_that_exists/file_that_exists.ext"
 

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -209,9 +209,9 @@ class MockOsPath:
         """Exists folder."""
         if file_or_path == "mock_folder_that_exists":
             return True
-        if file_or_path == "mock_folder_that_exists/nodes.cache":
+        if file_or_path == "mock_folder_that_exists/nodetype.cache":
             return True
-        if file_or_path == "mock_folder_that_exists\\nodes.cache":
+        if file_or_path == "mock_folder_that_exists\\nodetype.cache":
             return True
         if file_or_path == "mock_folder_that_exists/0123456789ABCDEF.cache":
             return True
@@ -1541,7 +1541,7 @@ class TestStick:
         async def aiofiles_os_remove(file: str) -> None:
             if file == "mock_folder_that_exists/file_that_exists.ext":
                 return
-            if file == "mock_folder_that_exists/nodes.cache":
+            if file == "mock_folder_that_exists/nodetype.cache":
                 return
             if file == "mock_folder_that_exists/0123456789ABCDEF.cache":
                 return
@@ -1644,7 +1644,7 @@ class TestStick:
         async def aiofiles_os_remove(file: str) -> None:
             if file == "mock_folder_that_exists/file_that_exists.ext":
                 return
-            if file == "mock_folder_that_exists/nodes.cache":
+            if file == "mock_folder_that_exists/nodetype.cache":
                 return
             if file == "mock_folder_that_exists/0123456789ABCDEF.cache":
                 return
@@ -1667,56 +1667,52 @@ class TestStick:
         await pw_nw_cache.initialize_cache()
         # test with invalid data
         mock_read_data = [
-            "-1;0123456789ABCDEF;NodeType.CIRCLE_PLUS",
-            "0;FEDCBA9876543210xxxNodeType.CIRCLE",
-            "invalid129834765AFBECD|NodeType.CIRCLE",
+            "0123456789ABCDEF;NodeType.CIRCLE_PLUS",
+            "FEDCBA9876543210;None",
         ]
         file_chunks_iter = iter(mock_read_data)
         mock_file_stream = MagicMock(readlines=lambda *args, **kwargs: file_chunks_iter)
         with patch("aiofiles.threadpool.sync_open", return_value=mock_file_stream):
             await pw_nw_cache.restore_cache()
-            assert pw_nw_cache.registrations == {
-                -1: ("0123456789ABCDEF", pw_api.NodeType.CIRCLE_PLUS),
+            assert pw_nw_cache.nodetypes == {
+                "0123456789ABCDEF": pw_api.NodeType.CIRCLE_PLUS,
             }
 
         # test with valid data
         mock_read_data = [
-            "-1;0123456789ABCDEF;NodeType.CIRCLE_PLUS",
-            "0;FEDCBA9876543210;NodeType.CIRCLE",
-            "1;1298347650AFBECD;NodeType.SCAN",
-            "2;;",
+            "0123456789ABCDEF;NodeType.CIRCLE_PLUS",
+            "FEDCBA9876543210;NodeType.CIRCLE",
+            "1298347650AFBECD;NodeType.SCAN",
         ]
         file_chunks_iter = iter(mock_read_data)
         mock_file_stream = MagicMock(readlines=lambda *args, **kwargs: file_chunks_iter)
         with patch("aiofiles.threadpool.sync_open", return_value=mock_file_stream):
             await pw_nw_cache.restore_cache()
-            assert pw_nw_cache.registrations == {
-                -1: ("0123456789ABCDEF", pw_api.NodeType.CIRCLE_PLUS),
-                0: ("FEDCBA9876543210", pw_api.NodeType.CIRCLE),
-                1: ("1298347650AFBECD", pw_api.NodeType.SCAN),
-                2: ("", None),
+            assert pw_nw_cache.nodetypes == {
+                "0123456789ABCDEF": pw_api.NodeType.CIRCLE_PLUS,
+                "FEDCBA9876543210": pw_api.NodeType.CIRCLE,
+                "1298347650AFBECD": pw_api.NodeType.SCAN,
             }
-        pw_nw_cache.update_registration(3, "1234ABCD4321FEDC", pw_api.NodeType.STEALTH)
+        pw_nw_cache.update_nodetypes("1234ABCD4321FEDC", pw_api.NodeType.STEALTH)
 
         with patch("aiofiles.threadpool.sync_open", return_value=mock_file_stream):
-            await pw_nw_cache.save_cache()
+            # await pw_nw_cache.save_cache()
+            await pw_nw_cache.update_nodetypes(
+                "1234ABCD4321FEDC", pw_api.NodeType.STEALTH
+            )
             mock_file_stream.writelines.assert_called_with(
                 [
-                    "-1;0123456789ABCDEF|NodeType.CIRCLE_PLUS\n",
-                    "0;FEDCBA9876543210|NodeType.CIRCLE\n",
-                    "1;1298347650AFBECD|NodeType.SCAN\n",
-                    "2;|\n",
-                    "3;1234ABCD4321FEDC|NodeType.STEALTH\n",
-                    "4;|\n",
+                    "0123456789ABCDEF;NodeType.CIRCLE_PLUS\n",
+                    "FEDCBA9876543210;NodeType.CIRCLE\n",
+                    "1298347650AFBECD;NodeType.SCAN\n",
+                    "1234ABCD4321FEDC;NodeType.STEALTH\n",
                 ]
-                + [f"{address};|\n" for address in range(5, 64)]
             )
-        assert pw_nw_cache.registrations == {
-            -1: ("0123456789ABCDEF", pw_api.NodeType.CIRCLE_PLUS),
-            0: ("FEDCBA9876543210", pw_api.NodeType.CIRCLE),
-            1: ("1298347650AFBECD", pw_api.NodeType.SCAN),
-            2: ("", None),
-            3: ("1234ABCD4321FEDC", pw_api.NodeType.STEALTH),
+        assert pw_nw_cache.nodetypes == {
+            "0123456789ABCDEF": pw_api.NodeType.CIRCLE_PLUS,
+            "FEDCBA9876543210": pw_api.NodeType.CIRCLE,
+            "1298347650AFBECD": pw_api.NodeType.SCAN,
+            "1234ABCD4321FEDC": pw_api.NodeType.STEALTH,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
If nodes were not discovered in the first three runs of discover_nodes (unplugged or long distance), nodes would not be discovered later and remain offline.

The scheduling itself feels like an ugly hack, maybe there is a better way to reschedule discover_nodes every minute until all nodes are online. Proposals are accepted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic, recurring attempts to discover and load registered nodes at regular intervals until all are found.

* **Enhancements**
  * Improved tracking and logging of node discovery with detailed node type info.
  * Enhanced node initialization to ensure nodes are initialized upon confirming online status.
  * Simplified and improved network cache handling with updated cache file format and asynchronous updates.
  * Refined node loading logic to verify availability before setup and initialization.
  * Updated tests to align with new cache structure and file format.
  * Removed explicit registry cache loading and saving for streamlined cache management.
  * Converted key network registration methods to asynchronous operations for improved performance.
  * Updated ignore rules to exclude files in a new mock folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->