### PR TITLE
Migrate to Trusted Publishing (pypi)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -26,20 +26,38 @@ jobs:
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare uv
         run: |
           pip install uv
           uv venv --seed venv
+          . venv/bin/activate
+          uv pip install toml
+      - name: Check for existing package on PyPI
+        id: check_package
+        run: |
+          . venv/bin/activate
+          PACKAGE_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          PACKAGE_NAME=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])")
+
+          # Use jq to check for the version in the releases object
+          EXISTING_VERSIONS=$(curl -s "https://pypi.org/pypi/$PACKAGE_NAME/json" | jq '.releases | keys[]')
+
+          echo "Checking for package: $PACKAGE_NAME==$PACKAGE_VERSION"
+
+          if [[ "$EXISTING_VERSIONS" =~ "$PACKAGE_VERSION" ]]; then
+            echo "Package version already exists. Skipping upload."
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Package version does not exist. Proceeding with upload."
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
       - name: Build
+        if: steps.check_package.outputs.should_publish == 'true'
         run: |
           . venv/bin/activate
           uv build
       - name: Publish distribution 📦 to PyPI
+        if: steps.check_package.outputs.should_publish == 'true'
         run: |
           . venv/bin/activate
           uv publish

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,12 +13,14 @@ on:
     types: closed
     branches:
       - main
-      - async
 
 jobs:
   publishing:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     # Only trigger on merges, not just closes
     if: github.event.pull_request.merged == true
     steps:
@@ -29,16 +31,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Install pypa/build
-        run: >-
-          python3 -m
-          pip install
-          build
-          --user
-      - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+      - name: Prepare uv
+        run: |
+          pip install uv
+          uv venv --seed venv
+      - name: Build
+        run: |
+          . venv/bin/activate
+          uv build
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.pypi_token }}
-          skip_existing: true
+        run: |
+          . venv/bin/activate
+          uv publish

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write
+      contents: read     # Required by actions/checkout
+      id-token: write    # Needed for OIDC-based Trusted Publishing
     # Only trigger on merges, not just closes
     if: github.event.pull_request.merged == true
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -275,7 +275,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
-      id-token: write
+      contents: read     # Required by actions/checkout
+      id-token: write    # Needed for OIDC-based Trusted Publishing
     needs:
       - cache
       - prepare

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -273,6 +273,9 @@ jobs:
   test-publishing:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI
     runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
     needs:
       - cache
       - prepare
@@ -281,34 +284,41 @@ jobs:
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Create or reuse cache
-        id: cache-reuse
-        uses: ./.github/actions/restore-venv
-        with:
-          cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ steps.python.outputs.python-version }}
-          venv-dir: ${{ env.VENV }}
-          precommit-home: ${{ env.PRE_COMMIT_HOME }}
-      - name: Install pypa/build
+      - name: Prepare uv
+        run: |
+          pip install uv
+          uv venv --seed venv
+          . venv/bin/activate
+          uv pip install toml
+      - name: Check for existing package on TestPyPI
+        id: check_package
         run: |
           . venv/bin/activate
-          uv pip install build
-      - name: Build a binary wheel and a source tarball
+          PACKAGE_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          PACKAGE_NAME=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])")
+
+          # Use jq to check for the version in the releases object
+          EXISTING_VERSIONS=$(curl -s "https://test.pypi.org/pypi/$PACKAGE_NAME/json" | jq '.releases | keys[]')
+
+          echo "Checking for package: $PACKAGE_NAME==$PACKAGE_VERSION"
+
+          if [[ "$EXISTING_VERSIONS" =~ "$PACKAGE_VERSION" ]]; then
+            echo "Package version already exists. Skipping upload."
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Package version does not exist. Proceeding with upload."
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Build
+        if: steps.check_package.outputs.should_publish == 'true'
         run: |
           . venv/bin/activate
-          python3 -m build
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
-        with:
-          password: ${{ secrets.testpypi_token }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          uv build
+      - name: Publish distribution 📦 to TestPyPI
+        if: steps.check_package.outputs.should_publish == 'true'
+        run: |
+          . venv/bin/activate
+          uv publish --publish-url https://test.pypi.org/legacy/
 
   complexity:
     name: Process test complexity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing / v0.44.8a0
+
+- Chores move module publishing on (test)pypi to Trusted Publishing (and using uv) - released as alpha 0.44.8a0 to demonstrate functionality
+
 ## v0.44.7 - 2025-07-08
 
 - PR [282](https://github.com/plugwise/python-plugwise-usb/pull/282): Finalize switch implementation


### PR DESCRIPTION
Also removed `async` branch from ability to merge since y'all 've completed that :)

Todo (to complete the PR)

- [ ] Verify the code
- [ ] Bump `pyproject.toml`s version to 0.44.8a0 (or anything a0 if merged later than other PRs)
- [ ] Check testpypi to see if it's released there
- [ ] Merge the PR
- [ ] Check pypi to ensure it's release there

No there will be no 'new' functionality in the release, but it's better to ensure everything works :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflows to use a new toolchain for building and publishing Python distributions.
  * Streamlined the build and publish process with a single utility for both PyPI and TestPyPI.
  * Introduced a check to prevent publishing package versions that already exist on TestPyPI.
  * Updated changelog to document these workflow improvements and the alpha release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->