### PR TITLE
Streamline of loading SED nodes.

### DIFF
--- a/plugwise_usb/nodes/__init__.py
+++ b/plugwise_usb/nodes/__init__.py
@@ -26,6 +26,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseCirclePlus(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )
@@ -33,6 +34,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseCircle(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )
@@ -40,6 +42,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseSwitch(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )
@@ -47,6 +50,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseSense(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )
@@ -54,6 +58,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseScan(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )
@@ -61,6 +66,7 @@ def get_plugwise_node(  # noqa: PLR0911
         return PlugwiseStealth(
             mac,
             address,
+            node_type,
             controller,
             loaded_callback,
         )

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -16,6 +16,7 @@ from ..api import (
     NodeFeature,
     NodeInfo,
     NodeInfoMessage,
+    NodeType,
     PowerStatistics,
     RelayConfig,
     RelayLock,
@@ -81,11 +82,12 @@ class PlugwiseCircle(PlugwiseBaseNode):
         self,
         mac: str,
         address: int,
+        node_type: NodeType,
         controller: StickController,
         loaded_callback: Callable[[NodeEvent, str], Awaitable[None]],
     ):
         """Initialize base class for Sleeping End Device."""
-        super().__init__(mac, address, controller, loaded_callback)
+        super().__init__(mac, address, node_type, controller, loaded_callback)
 
         # Relay
         self._relay_lock: RelayLock = RelayLock()

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, Final
 
-from ..api import BatteryConfig, NodeEvent, NodeFeature, NodeInfo
+from ..api import BatteryConfig, NodeEvent, NodeFeature, NodeInfo, NodeType
 from ..connection import StickController
 from ..constants import MAX_UINT_2, MAX_UINT_4
 from ..exceptions import MessageError, NodeError
@@ -64,6 +64,12 @@ SED_MAX_MAINTENANCE_INTERVAL_OFFSET: Final = 30  # seconds
 # Time in minutes the SED will sleep
 SED_DEFAULT_SLEEP_DURATION: Final = 60
 
+# Default firmware if not known
+DEFAULT_FIRMWARE: Final = None
+
+# SED BaseNode Features
+SED_FEATURES: Final = (NodeFeature.BATTERY,)
+
 # Value limits
 MAX_MINUTE_INTERVAL: Final = 1440
 
@@ -83,11 +89,12 @@ class NodeSED(PlugwiseBaseNode):
         self,
         mac: str,
         address: int,
+        node_type: NodeType,
         controller: StickController,
         loaded_callback: Callable[[NodeEvent, str], Awaitable[None]],
     ):
         """Initialize base class for Sleeping End Device."""
-        super().__init__(mac, address, controller, loaded_callback)
+        super().__init__(mac, address, node_type, controller, loaded_callback)
         self._loop = get_running_loop()
         self._node_info.is_battery_powered = True
 
@@ -117,12 +124,8 @@ class NodeSED(PlugwiseBaseNode):
         else:
             self._load_defaults()
         self._loaded = True
-        self._features += (NodeFeature.BATTERY,)
-        if await self.initialize():
-            await self._loaded_callback(NodeEvent.LOADED, self.mac)
-            return True
-        _LOGGER.debug("Load of SED node %s failed", self._node_info.mac)
-        return False
+        self._features += SED_FEATURES
+        return True
 
     async def unload(self) -> None:
         """Deactivate and unload node features."""
@@ -156,7 +159,7 @@ class NodeSED(PlugwiseBaseNode):
         await super().initialize()
         return True
 
-    def _load_defaults(self) -> None:
+    async def _load_defaults(self) -> None:
         """Load default configuration settings."""
         self._battery_config = BatteryConfig(
             awake_duration=SED_DEFAULT_AWAKE_DURATION,
@@ -165,11 +168,15 @@ class NodeSED(PlugwiseBaseNode):
             maintenance_interval=SED_DEFAULT_MAINTENANCE_INTERVAL,
             sleep_duration=SED_DEFAULT_SLEEP_DURATION,
         )
+        await self.schedule_task_when_awake(self.node_info_update(None))
+        self._sed_config_task_scheduled = True
+        self._new_battery_config = self._battery_config
+        await self.schedule_task_when_awake(self._configure_sed_task())
 
     async def _load_from_cache(self) -> bool:
         """Load states from previous cached information. Returns True if successful."""
         if not await super()._load_from_cache():
-            self._load_defaults()
+            await self._load_defaults()
             return False
         self._battery_config = BatteryConfig(
             awake_duration=self._awake_duration_from_cache(),
@@ -239,9 +246,6 @@ class NodeSED(PlugwiseBaseNode):
             raise ValueError(
                 f"Invalid awake duration ({seconds}). It must be between 1 and 255 seconds."
             )
-
-        if self._battery_config.awake_duration == seconds:
-            return False
 
         self._new_battery_config = replace(
             self._new_battery_config, awake_duration=seconds
@@ -491,7 +495,7 @@ class NodeSED(PlugwiseBaseNode):
         self, node_info: NodeInfoResponse | None = None
     ) -> NodeInfo | None:
         """Update Node (hardware) information."""
-        if node_info is None and self.skip_update(self._node_info, 86400):
+        if node_info is not None and self.skip_update(self._node_info, 86400):
             return self._node_info
         return await super().node_info_update(node_info)
 
@@ -643,7 +647,6 @@ class NodeSED(PlugwiseBaseNode):
         """Send all tasks in queue."""
         if len(self._send_task_queue) == 0:
             return
-
         async with self._send_task_lock:
             task_result = await gather(*self._send_task_queue)
             if not all(task_result):

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1789,7 +1789,11 @@ class TestStick:
             """Load callback for event."""
 
         test_node = pw_sed.PlugwiseBaseNode(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.CIRCLE,
+            mock_stick_controller,
+            load_callback,
         )
 
         # Validate base node properties which are always set
@@ -1928,7 +1932,11 @@ class TestStick:
             """Load callback for event."""
 
         test_sed = pw_sed.NodeSED(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.SCAN,
+            mock_stick_controller,
+            load_callback,
         )
         assert not test_sed.cache_enabled
 
@@ -1970,8 +1978,8 @@ class TestStick:
             assert await test_sed.set_awake_duration(0)
         with pytest.raises(ValueError):
             assert await test_sed.set_awake_duration(256)
-        assert not await test_sed.set_awake_duration(10)
-        assert not test_sed.sed_config_task_scheduled
+        assert await test_sed.set_awake_duration(10)
+        assert test_sed.sed_config_task_scheduled
         assert await test_sed.set_awake_duration(15)
         assert test_sed.sed_config_task_scheduled
         assert test_sed.battery_config.awake_duration == 15
@@ -2104,8 +2112,8 @@ class TestStick:
                 return "2011-6-27-8-55-44"
             if setting == pw_node.CACHE_HARDWARE:
                 return "080007"
-            if setting == pw_node.CACHE_NODE_TYPE:
-                return "6"
+            if setting == pw_node.CACHE_RELAY:
+                return "True"
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
             if setting == pw_sed.CACHE_AWAKE_DURATION:
@@ -2146,7 +2154,11 @@ class TestStick:
             """Load callback for event."""
 
         test_scan = pw_scan.PlugwiseScan(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.SCAN,
+            mock_stick_controller,
+            load_callback,
         )
         assert not test_scan.cache_enabled
         node_info = pw_api.NodeInfoMessage(
@@ -2166,8 +2178,8 @@ class TestStick:
             assert await test_scan.set_motion_reset_timer(0)
         with pytest.raises(ValueError):
             assert await test_scan.set_motion_reset_timer(256)
-        assert not await test_scan.set_motion_reset_timer(10)
-        assert not test_scan.scan_config_task_scheduled
+        assert await test_scan.set_motion_reset_timer(10)
+        assert test_scan.scan_config_task_scheduled
         assert await test_scan.set_motion_reset_timer(15)
         assert test_scan.scan_config_task_scheduled
         assert test_scan.reset_timer == 15
@@ -2251,7 +2263,11 @@ class TestStick:
         # scan with cache enabled
         mock_stick_controller.send_response = None
         test_scan = pw_scan.PlugwiseScan(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.SCAN,
+            mock_stick_controller,
+            load_callback,
         )
         node_info = pw_api.NodeInfoMessage(
             current_logaddress_pointer=None,
@@ -2295,10 +2311,10 @@ class TestStick:
                 return "2011-5-13-7-26-54"
             if setting == pw_node.CACHE_HARDWARE:
                 return "080029"
-            if setting == pw_node.CACHE_NODE_TYPE:
-                return "3"
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
+            if setting == pw_node.CACHE_RELAY:
+                return "True"
             if setting == pw_sed.CACHE_AWAKE_DURATION:
                 return "15"
             if setting == pw_sed.CACHE_CLOCK_INTERVAL:
@@ -2318,7 +2334,11 @@ class TestStick:
             """Load callback for event."""
 
         test_switch = pw_switch.PlugwiseSwitch(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.SWITCH,
+            mock_stick_controller,
+            load_callback,
         )
         assert not test_switch.cache_enabled
 
@@ -2344,7 +2364,11 @@ class TestStick:
 
         # switch with cache enabled
         test_switch = pw_switch.PlugwiseSwitch(
-            "1298347650AFBECD", 1, mock_stick_controller, load_callback
+            "1298347650AFBECD",
+            1,
+            pw_api.NodeType.SWITCH,
+            mock_stick_controller,
+            load_callback,
         )
         node_info = pw_api.NodeInfoMessage(
             current_logaddress_pointer=None,
@@ -2627,6 +2651,10 @@ class TestStick:
         assert stick.nodes["8888888888888888"].node_info.model_type is None
         assert stick.nodes["8888888888888888"].available
         assert stick.nodes["8888888888888888"].node_info.is_battery_powered
+        assert (
+            stick.nodes["8888888888888888"].node_info.node_type
+            == pw_api.NodeType.SWITCH
+        )
         assert sorted(stick.nodes["8888888888888888"].features) == sorted(
             (
                 pw_api.NodeFeature.AVAILABLE,


### PR DESCRIPTION
- Propagate NodeType to node on init, which makes loading of nodes faster and less (cache) errorprone.
- Unify loading of SED nodes
- Setup proper defaults for scan if cache is missing or lacking and requests updates when nodes are awake Fix testing. (If working needs to be extended to Sense and Switch).
   This prevents to None porpagation to HAS, but initially the firmware / hardware versions are defaults. These get requested and if found put to cache, there is no way yet to automatically propagate to HAS without a restart.