### PR TITLE
Improve registry discovery and SED/SCAN configuration management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Ongoing
+
+- Fix for [#296](https://github.com/plugwise/plugwise_usb-beta/issues/296) Improve C+ registry collection and node discovery
+- Improve SED and SCAN configuration handling, include dirty bit when configuration has changed
+
 ## v0.44.9 - 2025-07-24
 
 - Fix for [#293](https://github.com/plugwise/plugwise_usb-beta/issues/293) via PR [299](https://github.com/plugwise/python-plugwise-usb/pull/299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.44.10 - 2025-08-11
 
-- PR [302](https://github.com/plugwise/python-plugwise-usb/pull/302)  Improve registry discovery and SED/SCAN configuration management
+- PR [302](https://github.com/plugwise/python-plugwise-usb/pull/302) Improve registry discovery and SED/SCAN configuration management
 - Fix for [#296](https://github.com/plugwise/plugwise_usb-beta/issues/296) Improve C+ registry collection and node discovery
-- Improve SED and SCAN configuration handling, include dirty bit when configuration has changed
+- Improve SED and SCAN configuration handling, include dirty bool to indicate that the configuration has changed but the node has not yet received the update
 
 ## v0.44.9 - 2025-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.44.10 - 2025-08-11
 
-- PR [302] (https://github.com/plugwise/python-plugwise-usb/pull/302)  Improve registry discovery and SED/SCAN configuration management
+- PR [302](https://github.com/plugwise/python-plugwise-usb/pull/302)  Improve registry discovery and SED/SCAN configuration management
 - Fix for [#296](https://github.com/plugwise/plugwise_usb-beta/issues/296) Improve C+ registry collection and node discovery
 - Improve SED and SCAN configuration handling, include dirty bit when configuration has changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - PR [302](https://github.com/plugwise/python-plugwise-usb/pull/302) Improve registry discovery and SED/SCAN configuration management
 - Fix for [#296](https://github.com/plugwise/plugwise_usb-beta/issues/296) Improve C+ registry collection and node discovery
-- Improve SED and SCAN configuration handling, include dirty bool to indicate that the configuration has changed but the node has not yet received the update
+- Improve SED and SCAN configuration handling, include dirty bool to indicate that the configuration has changed but the node configuration has not yet.
 
 ## v0.44.9 - 2025-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Ongoing
+## v0.44.10 - 2025-08-11
 
+- PR [302] (https://github.com/plugwise/python-plugwise-usb/pull/302)  Improve registry discovery and SED/SCAN configuration management
 - Fix for [#296](https://github.com/plugwise/plugwise_usb-beta/issues/296) Improve C+ registry collection and node discovery
 - Improve SED and SCAN configuration handling, include dirty bit when configuration has changed
 

--- a/plugwise_usb/api.py
+++ b/plugwise_usb/api.py
@@ -19,7 +19,7 @@ class StickEvent(Enum):
     NETWORK_ONLINE = auto()
 
 
-class MotionSensitivity(IntEnumEnum):
+class MotionSensitivity(IntEnum):
     """Motion sensitivity levels for Scan devices."""
 
     HIGH = 20

--- a/plugwise_usb/api.py
+++ b/plugwise_usb/api.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum, auto
+from enum import Enum, IntEnum, auto
 import logging
 from typing import Any, Protocol
 
@@ -19,12 +19,12 @@ class StickEvent(Enum):
     NETWORK_ONLINE = auto()
 
 
-class MotionSensitivity(Enum):
+class MotionSensitivity(IntEnumEnum):
     """Motion sensitivity levels for Scan devices."""
 
-    HIGH = auto()
-    MEDIUM = auto()
-    OFF = auto()
+    HIGH = 20
+    MEDIUM = 30
+    OFF = 255
 
 
 class NodeEvent(Enum):

--- a/plugwise_usb/api.py
+++ b/plugwise_usb/api.py
@@ -233,14 +233,14 @@ class MotionConfig:
     Attributes:
         reset_timer: int | None: Motion reset timer in minutes before the motion detection is switched off.
         daylight_mode: bool | None: Motion detection when light level is below threshold.
-        sensitivity_level: MotionSensitivity | None: Motion sensitivity level.
+        sensitivity_level: int | None: Motion sensitivity level.
         dirty: bool: Settings changed, device update pending
 
     """
 
     daylight_mode: bool | None = None
     reset_timer: int | None = None
-    sensitivity_level: MotionSensitivity | None = None
+    sensitivity_level: int | None = None
     dirty: bool = False
 
 

--- a/plugwise_usb/api.py
+++ b/plugwise_usb/api.py
@@ -118,6 +118,7 @@ class BatteryConfig:
         clock_sync: bool | None: Indicate if the internal clock must be synced.
         maintenance_interval: int | None: Interval in minutes a battery powered devices is awake for maintenance purposes.
         sleep_duration: int | None: Interval in minutes a battery powered devices is sleeping.
+        dirty: bool: Settings changed, device update pending
 
     """
 
@@ -126,6 +127,7 @@ class BatteryConfig:
     clock_sync: bool | None = None
     maintenance_interval: int | None = None
     sleep_duration: int | None = None
+    dirty: bool = False
 
 
 @dataclass
@@ -232,12 +234,14 @@ class MotionConfig:
         reset_timer: int | None: Motion reset timer in minutes before the motion detection is switched off.
         daylight_mode: bool | None: Motion detection when light level is below threshold.
         sensitivity_level: MotionSensitivity | None: Motion sensitivity level.
+        dirty: bool: Settings changed, device update pending
 
     """
 
     daylight_mode: bool | None = None
     reset_timer: int | None = None
     sensitivity_level: MotionSensitivity | None = None
+    dirty: bool = False
 
 
 @dataclass

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -434,7 +434,7 @@ class StickNetwork:
         """Repeat Discovery of Nodes with unknown NodeType."""
         while len(self._registry_stragglers) > 0:
             await sleep(NODE_RETRY_DISCOVER_INTERVAL)
-            for mac in list(self._registry_stragglers):
+            for mac in self._registry_stragglers.copy():
                 if await self._discover_node(mac, None):
                     self._registry_stragglers.remove(mac)
             _LOGGER.debug(

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -434,8 +434,8 @@ class StickNetwork:
         """Repeat Discovery of Nodes with unknown NodeType."""
         while len(self._registry_stragglers) > 0:
             await sleep(NODE_RETRY_DISCOVER_INTERVAL)
-            for mac in self._registry_stragglers:
-                if not await self._discover_node(mac, None):
+            for mac in list(self._registry_stragglers):
+                if await self._discover_node(mac, None):
                     self._registry_stragglers.remove(mac)
             _LOGGER.debug(
                 "Total %s nodes unreachable having unknown NodeType",

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -146,7 +146,7 @@ class StickNetwork:
         return self._nodes
 
     @property
-    def registry(self) -> dict[int, tuple[str, NodeType | None]]:
+    def registry(self) -> list[str]:
         """Return dictionary with all registered (joined) nodes."""
         return self._register.registry
 

--- a/plugwise_usb/network/__init__.py
+++ b/plugwise_usb/network/__init__.py
@@ -517,8 +517,6 @@ class StickNetwork:
             await self.start(load=load)
         return True
 
-        return True
-
     async def stop(self) -> None:
         """Stop network discovery."""
         _LOGGER.debug("Stopping")

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -80,11 +80,11 @@ class NetworkRegistrationCache(PlugwiseCache):
 
     async def prune_cache(self, registry: list[str]) -> None:
         """Remove items from cache which are not found in registry scan."""
-        _new_nodetypes: dict[str, NodeType] = {}
+        new_nodetypes: dict[str, NodeType] = {}
         for mac in registry:
             if mac == "":
                 continue
             if (node_type := self.get_nodetype(mac)) is not None:
-                _new_nodetypes[mac] = node_type
-        self._nodetypes = _new_nodetypes
+                new_nodetypes[mac] = node_type
+        self._nodetypes = new_nodetypes
         await self.save_cache()

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -78,7 +78,7 @@ class NetworkRegistrationCache(PlugwiseCache):
         """Return NodeType from cache."""
         return self._nodetypes.get(mac)
 
-    async def prune_cache(self, registry: list(str)) -> None:
+    async def prune_cache(self, registry: list[str]) -> None:
         """Remove items from cache which are not found in registry scan."""
         _new_nodetypes: dict[str, NodeType] = {}
         for mac in registry:

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -163,7 +163,7 @@ class StickNetworkRegister:
         return self.registry[-1]
 
     async def update_network_nodetype(self, mac: str, node_type: NodeType) -> None:
-        """Update NodeType Inside Registry and Cache."""
+        """Update NodeType inside registry and cache."""
         if self._network_cache is None or mac == "":
             return
         await self._network_cache.update_nodetypes(mac, node_type)
@@ -228,7 +228,7 @@ class StickNetworkRegister:
         if self._scan_completed_callback is not None:
             await self._scan_completed_callback()
 
-    async def update_node_registration(self, mac: str) -> bool:
+    def update_node_registration(self, mac: str) -> bool:
         """Register (re)joined node to Plugwise network and return network address."""
         return self.update_network_registration(mac)
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -44,12 +44,10 @@ class StickNetworkRegister:
         self._network_cache: NetworkRegistrationCache | None = None
         self._loaded: bool = False
         self._registry: list[str] = []
-        self._first_free_address: int = 65
         self._registration_task: Task[None] | None = None
         self._start_node_discover: (
             Callable[[str, NodeType | None, bool], Awaitable[bool]] | None
         ) = None
-        self._full_scan_finished: Callable[[], Awaitable[None]] | None = None
         self._registration_scan_delay: float = CIRCLEPLUS_SCANREQUEST_MAINTENANCE
         self._scan_completed = False
         self._scan_completed_callback: Callable[[], Awaitable[None]] | None = None
@@ -110,10 +108,6 @@ class StickNetworkRegister:
     def scan_completed_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
         """Register method to be called when a node is found."""
         self._scan_completed_callback = callback
-
-    def full_scan_finished(self, callback: Callable[[], Awaitable[None]]) -> None:
-        """Register method to be called when full scan is finished."""
-        self._full_scan_finished = callback
 
     # endregion
 
@@ -191,9 +185,6 @@ class StickNetworkRegister:
                     "'empty'" if mac == "" else f"set to {mac}",
                 )
                 if mac == "":
-                    self._first_free_address = min(
-                        self._first_free_address, currentaddress
-                    )
                     continue
                 _maintenance_registry.append(mac)
                 if self.update_network_registration(mac):

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -99,7 +99,9 @@ class StickNetworkRegister:
         """Indicate if scan is completed."""
         return self._scan_completed
 
-    def start_node_discover(self, callback: Callable[[], Awaitable[None]]) -> None:
+    def start_node_discover(
+        self, callback: Callable[[str, NodeType | None, bool], Awaitable[None]]
+    ) -> None:
         """Register method to be called when a node is found."""
         self._start_node_discover = callback
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -108,16 +108,16 @@ class StickNetworkRegister:
     def scan_completed_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
         """Register async callback invoked when a node is found.
 
-            Args:
-                callback: Async callable with signature
-                    (mac: str, node_type: NodeType | None, ping_first: bool) -> bool.
-                    It must return True when discovery succeeded; return False to allow the caller
-                    to fall back (e.g., SED discovery path).
+        Args:
+            callback: Async callable with signature
+                (mac: str, node_type: NodeType | None, ping_first: bool) -> bool.
+                It must return True when discovery succeeded; return False to allow the caller
+                to fall back (e.g., SED discovery path).
 
-            Returns:
-                None
+        Returns:
+            None
 
-            """
+        """
 
         self._scan_completed_callback = callback
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -92,7 +92,7 @@ class StickNetworkRegister:
             self._network_cache.cache_root_directory = cache_folder
 
     @property
-    def registry(self) -> dict[int, tuple[str, NodeType | None]]:
+    def registry(self) -> list[str]:
         """Return dictionary with all joined nodes."""
         return deepcopy(self._registry)
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -47,7 +47,7 @@ class StickNetworkRegister:
         self._first_free_address: int = 65
         self._registration_task: Task[None] | None = None
         self._start_node_discover: (
-            Callable[[str, NodeType | None, bool], Awaitable[None]] | None
+            Callable[[str, NodeType | None, bool], Awaitable[bool]] | None
         ) = None
         self._full_scan_finished: Callable[[], Awaitable[None]] | None = None
         self._registration_scan_delay: float = CIRCLEPLUS_SCANREQUEST_MAINTENANCE
@@ -102,7 +102,7 @@ class StickNetworkRegister:
         return self._scan_completed
 
     def start_node_discover(
-        self, callback: Callable[[str, NodeType | None, bool], Awaitable[None]]
+        self, callback: Callable[[str, NodeType | None, bool], Awaitable[bool]]
     ) -> None:
         """Register method to be called when a node is found."""
         self._start_node_discover = callback

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -165,14 +165,14 @@ class StickNetworkRegister:
         await self._network_cache.update_nodetypes(mac, node_type)
 
     def update_network_registration(self, mac: str) -> bool:
-        """Add a mac to the network registration list return True new."""
+        """Add a mac to the network registration list return True if it was newly added."""
         if mac == "" or mac in self._registry:
             return False
         self._registry.append(mac)
         return True
 
     async def remove_network_registration(self, mac: str) -> None:
-        """Remove a mac to the network registration list."""
+        """Remove a mac from the network registration list."""
         if mac in self._registry:
             self._registry.remove(mac)
             if self._network_cache is not None:
@@ -225,7 +225,7 @@ class StickNetworkRegister:
             await self._scan_completed_callback()
 
     def update_node_registration(self, mac: str) -> bool:
-        """Register (re)joined node to Plugwise network and return network address."""
+        """Register (re)joined node to Plugwise network and return True if newly added."""
         return self.update_network_registration(mac)
 
     def _stop_registration_task(self) -> None:

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -106,7 +106,7 @@ class StickNetworkRegister:
         self._start_node_discover = callback
 
     def scan_completed_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
-        """Register method to be called when a node is found."""
+        """Register method to be called when a registry scan has completed."""
         self._scan_completed_callback = callback
 
     # endregion
@@ -257,8 +257,8 @@ class StickNetworkRegister:
                 f"The Zigbee network coordinator '{self._mac_nc!r}'"
                 + f" failed to unregister node '{mac}'"
             )
-        if self.node_is_registered(mac):
-            await self.remove_network_registration(mac)
+
+        await self.remove_network_registration(mac)
 
     async def clear_register_cache(self) -> None:
         """Clear current cache."""

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -108,8 +108,10 @@ class StickNetworkRegister:
             mac: Node MAC address.
             node_type: NodeType if known (from cache), else None.
             ping_first: True when invoked from cache phase, False during Circle+ scan or manual register.
+
         Returns:
             bool: True when discovery succeeded; False to allow caller to fallback (e.g., SED path).
+
         """
         self._start_node_discover = callback
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -46,7 +46,9 @@ class StickNetworkRegister:
         self._registry: list[str] = []
         self._first_free_address: int = 65
         self._registration_task: Task[None] | None = None
-        self._start_node_discover: Callable[[], Awaitable[None]] | None = None
+        self._start_node_discover: (
+            Callable[[str, NodeType | None, bool], Awaitable[None]] | None
+        ) = None
         self._full_scan_finished: Callable[[], Awaitable[None]] | None = None
         self._registration_scan_delay: float = CIRCLEPLUS_SCANREQUEST_MAINTENANCE
         self._scan_completed = False

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -106,7 +106,19 @@ class StickNetworkRegister:
         self._start_node_discover = callback
 
     def scan_completed_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
-        """Register method to be called when a registry scan has completed."""
+        """Register async callback invoked when a node is found.
+
+            Args:
+                callback: Async callable with signature
+                    (mac: str, node_type: NodeType | None, ping_first: bool) -> bool.
+                    It must return True when discovery succeeded; return False to allow the caller
+                    to fall back (e.g., SED discovery path).
+
+            Returns:
+                None
+
+            """
+
         self._scan_completed_callback = callback
 
     async def _exec_node_discover_callback(

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -158,12 +158,6 @@ class StickNetworkRegister:
             return True
         return False
 
-    def network_controller(self) -> tuple[str, NodeType | None]:
-        """Return the registration for the network controller."""
-        if self._registry.get(-1) is None:
-            raise NodeError("Unable to return network controller details")
-        return self.registry[-1]
-
     async def update_network_nodetype(self, mac: str, node_type: NodeType) -> None:
         """Update NodeType inside registry and cache."""
         if self._network_cache is None or mac == "":

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -252,7 +252,7 @@ class StickNetworkRegister:
         if not validate_mac(mac):
             raise NodeError(f"MAC {mac} invalid")
 
-        if mac not in self._registry():
+        if mac not in self._registry:
             raise NodeError(f"No existing Node ({mac}) found to unregister")
 
         request = NodeRemoveRequest(self._send_to_controller, self._mac_nc, mac)

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -118,7 +118,10 @@ class StickNetworkRegister:
         self._scan_completed_callback = callback
 
     async def _exec_node_discover_callback(
-        self, mac: str, node_type: NodeType | None, ping_first: bool,
+        self,
+        mac: str,
+        node_type: NodeType | None,
+        ping_first: bool,
     ) -> None:
         """Protect _start_node_discover() callback execution."""
         if self._start_node_discover is not None:
@@ -127,13 +130,9 @@ class StickNetworkRegister:
             except CancelledError:
                 raise
             except Exception:
-                _LOGGER.exception(
-                    "start_node_discover callback failed for %s", mac
-                )
+                _LOGGER.exception("start_node_discover callback failed for %s", mac)
         else:
-            _LOGGER.debug(
-                "No start_node_discover callback set; skipping for %s", mac
-            )
+            _LOGGER.debug("No start_node_discover callback set; skipping for %s", mac)
 
     # endregion
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -118,7 +118,6 @@ class StickNetworkRegister:
             None
 
         """
-
         self._scan_completed_callback = callback
 
     async def _exec_node_discover_callback(

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -102,17 +102,7 @@ class StickNetworkRegister:
     def start_node_discover(
         self, callback: Callable[[str, NodeType | None, bool], Awaitable[bool]]
     ) -> None:
-        """Register async callback invoked when a node is found.
-
-        Args:
-            mac: Node MAC address.
-            node_type: NodeType if known (from cache), else None.
-            ping_first: True when invoked from cache phase, False during Circle+ scan or manual register.
-
-        Returns:
-            bool: True when discovery succeeded; False to allow caller to fallback (e.g., SED path).
-
-        """
+        """Register async callback invoked when a node is found."""
         self._start_node_discover = callback
 
     def scan_completed_callback(self, callback: Callable[[], Awaitable[None]]) -> None:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -975,13 +975,10 @@ class PlugwiseCircle(PlugwiseBaseNode):
         """Load default configuration settings."""
         if self._node_info.model is None:
             self._node_info.model = "Circle"
-            self._sed_node_info_update_task_scheduled = True
         if self._node_info.name is None:
             self._node_info.name = f"Circle {self._node_info.mac[-5:]}"
-            self._sed_node_info_update_task_scheduled = True
         if self._node_info.firmware is None:
             self._node_info.firmware = DEFAULT_FIRMWARE
-            self._sed_node_info_update_task_scheduled = True
 
     @raise_not_loaded
     async def initialize(self) -> bool:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -973,10 +973,13 @@ class PlugwiseCircle(PlugwiseBaseNode):
         """Load default configuration settings."""
         if self._node_info.model is None:
             self._node_info.model = "Circle"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.name is None:
             self._node_info.name = f"Circle {self._node_info.mac[-5:]}"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.firmware is None:
             self._node_info.firmware = DEFAULT_FIRMWARE
+            self._sed_node_info_update_task_scheduled = True
 
     @raise_not_loaded
     async def initialize(self) -> bool:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -910,8 +910,10 @@ class PlugwiseCircle(PlugwiseBaseNode):
 
             # Check if node is online
             if (
-                not self._available and not await self.is_online()
-            ) or await self.node_info_update() is None:
+                not self._available
+                and not await self.is_online()
+                or await self.node_info_update() is None
+            ):
                 _LOGGER.debug(
                     "Failed to retrieve NodeInfo for %s, loading defaults",
                     self._mac_in_str,

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -655,6 +655,14 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
             return None
         return self._node_cache.get_state(setting)
 
+    def _get_cache_as_bool(self, setting: str) -> bool | None:
+        """Retrieve bool of specified setting from cache memory."""
+        if not self._cache_enabled:
+            return None
+        if self._node_cache.get_state(setting) == "True":
+            return True
+        return False
+
     def _get_cache_as_datetime(self, setting: str) -> datetime | None:
         """Retrieve value of specified setting from cache memory and return it as datetime object."""
         if (timestamp_str := self._get_cache(setting)) is not None:

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -659,9 +659,9 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
         """Retrieve bool of specified setting from cache memory."""
         if not self._cache_enabled:
             return None
-        if self._node_cache.get_state(setting) == "True":
-            return True
-        return False
+        if (bool_value := self._node_cache.get_state(setting)) is None:
+            return None
+        return bool_value == "True"
 
     def _get_cache_as_datetime(self, setting: str) -> datetime | None:
         """Retrieve value of specified setting from cache memory and return it as datetime object."""

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -207,7 +207,7 @@ class PlugwiseScan(NodeSED):
         if (
             sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)
         ) is not None:
-            return MotionSensitivity[sensitivity_level]
+            return MotionSensitivity(int(sensitivity_level))
         return None
 
     def _motion_config_dirty_from_cache(self) -> bool:
@@ -483,7 +483,7 @@ class PlugwiseScan(NodeSED):
             CACHE_SCAN_CONFIG_RESET_TIMER, str(self._motion_config.reset_timer)
         )
         self._set_cache(
-            CACHE_SCAN_CONFIG_SENSITIVITY, self._motion_config.sensitivity_level
+            CACHE_SCAN_CONFIG_SENSITIVITY, self._motion_config.sensitivity_level.value
         )
         self._set_cache(
             CACHE_SCAN_CONFIG_DAYLIGHT_MODE, str(self._motion_config.daylight_mode)

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -202,12 +202,12 @@ class PlugwiseScan(NodeSED):
             return int(reset_timer)
         return None
 
-    def _sensitivity_level_from_cache(self) -> str | None:
+    def _sensitivity_level_from_cache(self) -> int | None:
         """Load sensitivity level from cache."""
         if (
             sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)
         ) is not None:
-            return MOTION_SENSITIVITY[sensitivity_level]
+            return int(sensitivity_level)
         return None
 
     def _motion_config_dirty_from_cache(self) -> bool:

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -164,7 +164,7 @@ class PlugwiseScan(NodeSED):
         if (sensitivity_level := self._sensitivity_level_from_cache()) is None:
             dirty = True
             sensitivity_level = DEFAULT_SENSITIVITY
-        dirty &= self._motion_config_dirty_from_cache()
+        dirty |= self._motion_config_dirty_from_cache()
 
         self._motion_config = MotionConfig(
             daylight_mode=daylight_mode,

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -201,7 +201,9 @@ class PlugwiseScan(NodeSED):
     def _sensitivity_level_from_cache(self) -> int | None:
         """Load sensitivity level from cache."""
         if (
-            sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)  # returns level in string CAPITALS
+            sensitivity_level := self._get_cache(
+                CACHE_SCAN_CONFIG_SENSITIVITY
+            )  # returns level in string CAPITALS
         ) is not None:
             return MotionSensitivity[sensitivity_level]
         return None
@@ -471,9 +473,8 @@ class PlugwiseScan(NodeSED):
             CACHE_SCAN_CONFIG_RESET_TIMER, str(self._motion_config.reset_timer)
         )
         self._set_cache(
-            CACHE_SCAN_CONFIG_SENSITIVITY, str(
-                MotionSensitivity(self._motion_config.sensitivity_level).name
-            )
+            CACHE_SCAN_CONFIG_SENSITIVITY,
+            str(MotionSensitivity(self._motion_config.sensitivity_level).name),
         )
         self._set_cache(
             CACHE_SCAN_CONFIG_DAYLIGHT_MODE, str(self._motion_config.daylight_mode)

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -423,13 +423,11 @@ class PlugwiseScan(NodeSED):
                 ]
             )
 
-    async def _run_awake_tasks(self) -> bool:
+    async def _run_awake_tasks(self) -> None:
         """Execute all awake tasks."""
-        if not await super()._run_awake_tasks():
-            return False
+        await super()._run_awake_tasks()
         if self._motion_config.dirty:
             await self._configure_scan_task()
-        return True
 
     async def _configure_scan_task(self) -> bool:
         """Configure Scan device settings. Returns True if successful."""

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -178,13 +178,7 @@ class PlugwiseScan(NodeSED):
 
     def _daylight_mode_from_cache(self) -> bool | None:
         """Load awake duration from cache."""
-        if (
-            daylight_mode := self._get_cache(CACHE_SCAN_CONFIG_DAYLIGHT_MODE)
-        ) is not None:
-            if daylight_mode == "True":
-                return True
-            return False
-        return None
+        return self._get_cache_as_bool(CACHE_SCAN_CONFIG_DAYLIGHT_MODE)
 
     def _motion_from_cache(self) -> bool:
         """Load motion state from cache."""
@@ -218,7 +212,7 @@ class PlugwiseScan(NodeSED):
 
     def _motion_config_dirty_from_cache(self) -> bool:
         """Load dirty  from cache."""
-        if (dirty := self._get_cache(CACHE_SCAN_CONFIG_DIRTY)) is not None:
+        if (dirty := self._get_cache_as_bool(CACHE_SCAN_CONFIG_DIRTY)) is not None:
             return dirty
         return True
 

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -28,32 +28,32 @@ from ..messages.responses import (
     PlugwiseResponse,
 )
 from ..nodes.sed import NodeSED
-from .helpers import raise_not_loaded
 from .helpers.firmware import SCAN_FIRMWARE_SUPPORT
 
 _LOGGER = logging.getLogger(__name__)
 
-CACHE_MOTION_STATE = "motion_state"
-CACHE_MOTION_TIMESTAMP = "motion_timestamp"
-CACHE_MOTION_RESET_TIMER = "motion_reset_timer"
+CACHE_SCAN_MOTION_STATE = "motion_state"
+CACHE_SCAN_MOTION_TIMESTAMP = "motion_timestamp"
 
-CACHE_SCAN_SENSITIVITY = "scan_sensitivity_level"
-CACHE_SCAN_DAYLIGHT_MODE = "scan_daylight_mode"
+CACHE_SCAN_CONFIG_DAYLIGHT_MODE = "scan_daylight_mode"
+CACHE_SCAN_CONFIG_DIRTY = "scan_config_dirty"
+CACHE_SCAN_CONFIG_RESET_TIMER = "motion_reset_timer"
+CACHE_SCAN_CONFIG_SENSITIVITY = "scan_sensitivity_level"
 
 
 # region Defaults for Scan Devices
 
-SCAN_DEFAULT_MOTION_STATE: Final = False
+DEFAULT_MOTION_STATE: Final = False
 
 # Time in minutes the motion sensor should not sense motion to
 # report "no motion" state [Source: 1min - 4uur]
-SCAN_DEFAULT_MOTION_RESET_TIMER: Final = 10
+DEFAULT_RESET_TIMER: Final = 10
 
 # Default sensitivity of the motion sensors
-SCAN_DEFAULT_SENSITIVITY: Final = MotionSensitivity.MEDIUM
+DEFAULT_SENSITIVITY: Final = MotionSensitivity.MEDIUM
 
 # Light override
-SCAN_DEFAULT_DAYLIGHT_MODE: Final = False
+DEFAULT_DAYLIGHT_MODE: Final = False
 
 # Default firmware if not known
 DEFAULT_FIRMWARE: Final = datetime(2010, 11, 4, 16, 58, 46, tzinfo=UTC)
@@ -90,11 +90,7 @@ class PlugwiseScan(NodeSED):
 
         self._motion_state = MotionState()
         self._motion_config = MotionConfig()
-        self._new_daylight_mode: bool | None = None
-        self._new_reset_timer: int | None = None
-        self._new_sensitivity_level: MotionSensitivity | None = None
 
-        self._scan_config_task_scheduled = False
         self._configure_daylight_mode_task: Task[Coroutine[Any, Any, None]] | None = (
             None
         )
@@ -113,7 +109,6 @@ class PlugwiseScan(NodeSED):
         await self.initialize()
         await self._loaded_callback(NodeEvent.LOADED, self.mac)
 
-    @raise_not_loaded
     async def initialize(self) -> None:
         """Initialize Scan node."""
         if self._initialized:
@@ -136,52 +131,66 @@ class PlugwiseScan(NodeSED):
     async def _load_defaults(self) -> None:
         """Load default configuration settings."""
         await super()._load_defaults()
-        self._motion_state = MotionState(
-            state=SCAN_DEFAULT_MOTION_STATE,
-            timestamp=None,
-        )
-        self._motion_config = MotionConfig(
-            reset_timer=SCAN_DEFAULT_MOTION_RESET_TIMER,
-            daylight_mode=SCAN_DEFAULT_DAYLIGHT_MODE,
-            sensitivity_level=SCAN_DEFAULT_SENSITIVITY,
-        )
         if self._node_info.model is None:
             self._node_info.model = "Scan"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.name is None:
             self._node_info.name = f"Scan {self._node_info.mac[-5:]}"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.firmware is None:
             self._node_info.firmware = DEFAULT_FIRMWARE
-        self._new_reset_timer = SCAN_DEFAULT_MOTION_RESET_TIMER
-        self._new_daylight_mode = SCAN_DEFAULT_DAYLIGHT_MODE
-        self._new_sensitivity_level = SCAN_DEFAULT_SENSITIVITY
-        self._scan_config_task_scheduled = True
+            self._sed_node_info_update_task_scheduled = True
+        if self._sed_node_info_update_task_scheduled:
+            _LOGGER.debug(
+                "NodeInfo cache-miss for node %s, assuming defaults", self._mac_in_str
+            )
 
     async def _load_from_cache(self) -> bool:
         """Load states from previous cached information. Returns True if successful."""
+        LoadSuccess = True
         if not await super()._load_from_cache():
-            return False
+            LoadSuccess = False
         self._motion_state = MotionState(
             state=self._motion_from_cache(),
             timestamp=self._motion_timestamp_from_cache(),
         )
-        self._motion_config = MotionConfig(
-            daylight_mode=self._daylight_mode_from_cache(),
-            reset_timer=self._reset_timer_from_cache(),
-            sensitivity_level=self._sensitivity_level_from_cache(),
-        )
-        return True
+        dirty = False
+        if (daylight_mode := self._daylight_mode_from_cache()) is None:
+            dirty = True
+            daylight_mode = DEFAULT_DAYLIGHT_MODE
+        if (reset_timer := self._reset_timer_from_cache()) is None:
+            dirty = True
+            reset_timer = DEFAULT_RESET_TIMER
+        if (sensitivity_level := self._sensitivity_level_from_cache()) is None:
+            dirty = True
+            sensitivity_level = DEFAULT_SENSITIVITY
+        dirty &= self._motion_config_dirty_from_cache()
 
-    def _daylight_mode_from_cache(self) -> bool:
+        self._motion_config = MotionConfig(
+            daylight_mode=daylight_mode,
+            reset_timer=reset_timer,
+            sensitivity_level=sensitivity_level,
+            dirty=dirty,
+        )
+        if dirty:
+            await self._scan_configure_update()
+        return LoadSuccess
+
+    def _daylight_mode_from_cache(self) -> bool | None:
         """Load awake duration from cache."""
-        if (daylight_mode := self._get_cache(CACHE_SCAN_DAYLIGHT_MODE)) is not None:
+        if (
+            daylight_mode := self._get_cache(CACHE_SCAN_CONFIG_DAYLIGHT_MODE)
+        ) is not None:
             if daylight_mode == "True":
                 return True
             return False
-        return SCAN_DEFAULT_DAYLIGHT_MODE
+        return None
 
     def _motion_from_cache(self) -> bool:
         """Load motion state from cache."""
-        if (cached_motion_state := self._get_cache(CACHE_MOTION_STATE)) is not None:
+        if (
+            cached_motion_state := self._get_cache(CACHE_SCAN_MOTION_STATE)
+        ) is not None:
             if (
                 cached_motion_state == "True"
                 and (motion_timestamp := self._motion_timestamp_from_cache())
@@ -191,24 +200,32 @@ class PlugwiseScan(NodeSED):
             ):
                 return True
             return False
-        return SCAN_DEFAULT_MOTION_STATE
+        return DEFAULT_MOTION_STATE
 
-    def _reset_timer_from_cache(self) -> int:
+    def _reset_timer_from_cache(self) -> int | None:
         """Load reset timer from cache."""
-        if (reset_timer := self._get_cache(CACHE_MOTION_RESET_TIMER)) is not None:
+        if (reset_timer := self._get_cache(CACHE_SCAN_CONFIG_RESET_TIMER)) is not None:
             return int(reset_timer)
-        return SCAN_DEFAULT_MOTION_RESET_TIMER
+        return None
 
-    def _sensitivity_level_from_cache(self) -> MotionSensitivity:
+    def _sensitivity_level_from_cache(self) -> MotionSensitivity | None:
         """Load sensitivity level from cache."""
-        if (sensitivity_level := self._get_cache(CACHE_SCAN_SENSITIVITY)) is not None:
+        if (
+            sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)
+        ) is not None:
             return MotionSensitivity[sensitivity_level]
-        return SCAN_DEFAULT_SENSITIVITY
+        return None
+
+    def _motion_config_dirty_from_cache(self) -> bool:
+        """Load dirty  from cache."""
+        if (dirty := self._get_cache(CACHE_SCAN_CONFIG_DIRTY)) is not None:
+            return dirty
+        return True
 
     def _motion_timestamp_from_cache(self) -> datetime | None:
         """Load motion timestamp from cache."""
         if (
-            motion_timestamp := self._get_cache_as_datetime(CACHE_MOTION_TIMESTAMP)
+            motion_timestamp := self._get_cache_as_datetime(CACHE_SCAN_MOTION_TIMESTAMP)
         ) is not None:
             return motion_timestamp
         return None
@@ -218,17 +235,13 @@ class PlugwiseScan(NodeSED):
     # region Properties
 
     @property
-    @raise_not_loaded
     def daylight_mode(self) -> bool:
         """Daylight mode of motion sensor."""
-        if self._new_daylight_mode is not None:
-            return self._new_daylight_mode
         if self._motion_config.daylight_mode is not None:
             return self._motion_config.daylight_mode
-        return SCAN_DEFAULT_DAYLIGHT_MODE
+        return DEFAULT_DAYLIGHT_MODE
 
     @property
-    @raise_not_loaded
     def motion(self) -> bool:
         """Motion detection value."""
         if self._motion_state.state is not None:
@@ -236,13 +249,11 @@ class PlugwiseScan(NodeSED):
         raise NodeError(f"Motion state is not available for {self.name}")
 
     @property
-    @raise_not_loaded
     def motion_state(self) -> MotionState:
         """Motion detection state."""
         return self._motion_state
 
     @property
-    @raise_not_loaded
     def motion_timestamp(self) -> datetime:
         """Timestamp of last motion state change."""
         if self._motion_state.timestamp is not None:
@@ -250,7 +261,6 @@ class PlugwiseScan(NodeSED):
         raise NodeError(f"Motion timestamp is currently not available for {self.name}")
 
     @property
-    @raise_not_loaded
     def motion_config(self) -> MotionConfig:
         """Motion configuration."""
         return MotionConfig(
@@ -260,33 +270,22 @@ class PlugwiseScan(NodeSED):
         )
 
     @property
-    @raise_not_loaded
     def reset_timer(self) -> int:
         """Total minutes without motion before no motion is reported."""
-        if self._new_reset_timer is not None:
-            return self._new_reset_timer
         if self._motion_config.reset_timer is not None:
             return self._motion_config.reset_timer
-        return SCAN_DEFAULT_MOTION_RESET_TIMER
-
-    @property
-    def scan_config_task_scheduled(self) -> bool:
-        """Check if a configuration task is scheduled."""
-        return self._scan_config_task_scheduled
+        return DEFAULT_RESET_TIMER
 
     @property
     def sensitivity_level(self) -> MotionSensitivity:
         """Sensitivity level of motion sensor."""
-        if self._new_sensitivity_level is not None:
-            return self._new_sensitivity_level
         if self._motion_config.sensitivity_level is not None:
             return self._motion_config.sensitivity_level
-        return SCAN_DEFAULT_SENSITIVITY
+        return DEFAULT_SENSITIVITY
 
     # endregion
     # region Configuration actions
 
-    @raise_not_loaded
     async def set_motion_daylight_mode(self, state: bool) -> bool:
         """Configure if motion must be detected when light level is below threshold.
 
@@ -298,18 +297,16 @@ class PlugwiseScan(NodeSED):
             self._motion_config.daylight_mode,
             state,
         )
-        self._new_daylight_mode = state
         if self._motion_config.daylight_mode == state:
             return False
-        if not self._scan_config_task_scheduled:
-            self._scan_config_task_scheduled = True
-            _LOGGER.debug(
-                "set_motion_daylight_mode | Device %s | config scheduled",
-                self.name,
-            )
+        self._motion_config = replace(
+            self._motion_config,
+            daylight_mode=state,
+            dirty=True,
+        )
+        await self._scan_configure_update()
         return True
 
-    @raise_not_loaded
     async def set_motion_reset_timer(self, minutes: int) -> bool:
         """Configure the motion reset timer in minutes."""
         _LOGGER.debug(
@@ -322,18 +319,16 @@ class PlugwiseScan(NodeSED):
             raise ValueError(
                 f"Invalid motion reset timer ({minutes}). It must be between 1 and 255 minutes."
             )
-        self._new_reset_timer = minutes
         if self._motion_config.reset_timer == minutes:
             return False
-        if not self._scan_config_task_scheduled:
-            self._scan_config_task_scheduled = True
-            _LOGGER.debug(
-                "set_motion_reset_timer | Device %s | config scheduled",
-                self.name,
-            )
+        self._motion_config = replace(
+            self._motion_config,
+            reset_timer=minutes,
+            dirty=True,
+        )
+        await self._scan_configure_update()
         return True
 
-    @raise_not_loaded
     async def set_motion_sensitivity_level(self, level: MotionSensitivity) -> bool:
         """Configure the motion sensitivity level."""
         _LOGGER.debug(
@@ -342,15 +337,14 @@ class PlugwiseScan(NodeSED):
             self._motion_config.sensitivity_level,
             level,
         )
-        self._new_sensitivity_level = level
         if self._motion_config.sensitivity_level == level:
             return False
-        if not self._scan_config_task_scheduled:
-            self._scan_config_task_scheduled = True
-            _LOGGER.debug(
-                "set_motion_sensitivity_level | Device %s | config scheduled",
-                self.name,
-            )
+        self._motion_config = replace(
+            self._motion_config,
+            sensitivity_level=level,
+            dirty=True,
+        )
+        await self._scan_configure_update()
         return True
 
     # endregion
@@ -385,12 +379,12 @@ class PlugwiseScan(NodeSED):
         )
         state_update = False
         if motion_state:
-            self._set_cache(CACHE_MOTION_STATE, "True")
+            self._set_cache(CACHE_SCAN_MOTION_STATE, "True")
             if self._motion_state.state is None or not self._motion_state.state:
                 self._reset_timer_motion_on = timestamp
                 state_update = True
         else:
-            self._set_cache(CACHE_MOTION_STATE, "False")
+            self._set_cache(CACHE_SCAN_MOTION_STATE, "False")
             if self._motion_state.state is None or self._motion_state.state:
                 if self._reset_timer_motion_on is not None:
                     reset_timer = int(
@@ -398,9 +392,9 @@ class PlugwiseScan(NodeSED):
                     )
                     if self._motion_config.reset_timer is None:
                         self._motion_config = replace(
-                            self._motion_config,
-                            reset_timer=reset_timer,
+                            self._motion_config, reset_timer=reset_timer, dirty=True
                         )
+                        await self._scan_configure_update()
                     elif reset_timer < self._motion_config.reset_timer:
                         _LOGGER.warning(
                             "Adjust reset timer for %s from %s -> %s",
@@ -409,11 +403,11 @@ class PlugwiseScan(NodeSED):
                             reset_timer,
                         )
                         self._motion_config = replace(
-                            self._motion_config,
-                            reset_timer=reset_timer,
+                            self._motion_config, reset_timer=reset_timer, dirty=True
                         )
+                        await self._scan_configure_update()
                 state_update = True
-        self._set_cache(CACHE_MOTION_TIMESTAMP, timestamp)
+        self._set_cache(CACHE_SCAN_MOTION_TIMESTAMP, timestamp)
         if state_update:
             self._motion_state = replace(
                 self._motion_state,
@@ -433,58 +427,19 @@ class PlugwiseScan(NodeSED):
     async def _run_awake_tasks(self) -> None:
         """Execute all awake tasks."""
         await super()._run_awake_tasks()
-        if self._scan_config_task_scheduled and await self._configure_scan_task():
-            self._scan_config_task_scheduled = False
+        if self._motion_config.dirty:
+            await self._configure_scan_task()
 
     async def _configure_scan_task(self) -> bool:
         """Configure Scan device settings. Returns True if successful."""
-        change_required = False
-        if self._new_reset_timer is not None:
-            change_required = True
-        if self._new_sensitivity_level is not None:
-            change_required = True
-        if self._new_daylight_mode is not None:
-            change_required = True
-        if not change_required:
+        if not self._motion_config.dirty:
             return True
-        if not await self.scan_configure(
-            motion_reset_timer=self.reset_timer,
-            sensitivity_level=self.sensitivity_level,
-            daylight_mode=self.daylight_mode,
-        ):
+        if not await self.scan_configure():
+            _LOGGER.debug("Motion Configuration for %s failed", self._mac_in_str)
             return False
-        if self._new_reset_timer is not None:
-            _LOGGER.info(
-                "Change of motion reset timer from %s to %s minutes has been accepted by %s",
-                self._motion_config.reset_timer,
-                self._new_reset_timer,
-                self.name,
-            )
-            self._new_reset_timer = None
-        if self._new_sensitivity_level is not None:
-            _LOGGER.info(
-                "Change of sensitivity level from %s to %s has been accepted by %s",
-                self._motion_config.sensitivity_level,
-                self._new_sensitivity_level,
-                self.name,
-            )
-            self._new_sensitivity_level = None
-        if self._new_daylight_mode is not None:
-            _LOGGER.info(
-                "Change of daylight mode from %s to %s has been accepted by %s",
-                "On" if self._motion_config.daylight_mode else "Off",
-                "On" if self._new_daylight_mode else "Off",
-                self.name,
-            )
-            self._new_daylight_mode = None
         return True
 
-    async def scan_configure(
-        self,
-        motion_reset_timer: int,
-        sensitivity_level: MotionSensitivity,
-        daylight_mode: bool,
-    ) -> bool:
+    async def scan_configure(self) -> bool:
         """Configure Scan device settings. Returns True if successful."""
         sensitivity_map = {
             MotionSensitivity.HIGH: SENSITIVITY_HIGH_VALUE,
@@ -493,60 +448,48 @@ class PlugwiseScan(NodeSED):
         }
         # Default to medium
         sensitivity_value = sensitivity_map.get(
-            sensitivity_level, SENSITIVITY_MEDIUM_VALUE
+            self._motion_config.sensitivity_level, SENSITIVITY_MEDIUM_VALUE
         )
         request = ScanConfigureRequest(
             self._send,
             self._mac_in_bytes,
-            motion_reset_timer,
+            self._motion_config.reset_timer,
             sensitivity_value,
-            daylight_mode,
+            self._motion_config.daylight_mode,
         )
-        if (response := await request.send()) is not None:
-            if response.node_ack_type == NodeAckResponseType.SCAN_CONFIG_FAILED:
-                self._new_reset_timer = None
-                self._new_sensitivity_level = None
-                self._new_daylight_mode = None
-                _LOGGER.warning("Failed to configure scan settings for %s", self.name)
-                return False
-
-            if response.node_ack_type == NodeAckResponseType.SCAN_CONFIG_ACCEPTED:
-                await self._scan_configure_update(
-                    motion_reset_timer, sensitivity_level, daylight_mode
-                )
-                return True
-
+        if (response := await request.send()) is None:
             _LOGGER.warning(
-                "Unexpected response ack type %s for %s",
-                response.node_ack_type,
-                self.name,
+                "No response from %s to configure motion settings request", self.name
             )
             return False
+        if response.node_ack_type == NodeAckResponseType.SCAN_CONFIG_FAILED:
+            _LOGGER.warning("Failed to configure scan settings for %s", self.name)
+            return False
+        if response.node_ack_type == NodeAckResponseType.SCAN_CONFIG_ACCEPTED:
+            _LOGGER.debug("Successful configure scan settings for %s", self.name)
+            self._motion_config = replace(self._motion_config, dirty=False)
+            await self._scan_configure_update()
+            return True
 
-        self._new_reset_timer = None
-        self._new_sensitivity_level = None
-        self._new_daylight_mode = None
+        _LOGGER.warning(
+            "Unexpected response ack type %s for %s",
+            response.node_ack_type,
+            self.name,
+        )
         return False
 
-    async def _scan_configure_update(
-        self,
-        motion_reset_timer: int,
-        sensitivity_level: MotionSensitivity,
-        daylight_mode: bool,
-    ) -> None:
-        """Process result of scan configuration update."""
-        self._motion_config = replace(
-            self._motion_config,
-            reset_timer=motion_reset_timer,
-            sensitivity_level=sensitivity_level,
-            daylight_mode=daylight_mode,
+    async def _scan_configure_update(self) -> None:
+        """Push scan configuration update to cache."""
+        self._set_cache(
+            CACHE_SCAN_CONFIG_RESET_TIMER, str(self._motion_config.reset_timer)
         )
-        self._set_cache(CACHE_MOTION_RESET_TIMER, str(motion_reset_timer))
-        self._set_cache(CACHE_SCAN_SENSITIVITY, sensitivity_level.name)
-        if daylight_mode:
-            self._set_cache(CACHE_SCAN_DAYLIGHT_MODE, "True")
-        else:
-            self._set_cache(CACHE_SCAN_DAYLIGHT_MODE, "False")
+        self._set_cache(
+            CACHE_SCAN_CONFIG_SENSITIVITY, self._motion_config.sensitivity_level
+        )
+        self._set_cache(
+            CACHE_SCAN_CONFIG_DAYLIGHT_MODE, str(self._motion_config.daylight_mode)
+        )
+        self._set_cache(CACHE_SCAN_CONFIG_DIRTY, str(self._motion_config.dirty))
         await gather(
             self.publish_feature_update_to_subscribers(
                 NodeFeature.MOTION_CONFIG,
@@ -570,7 +513,6 @@ class PlugwiseScan(NodeSED):
             + "to light calibration request."
         )
 
-    @raise_not_loaded
     async def get_state(self, features: tuple[NodeFeature]) -> dict[NodeFeature, Any]:
         """Update latest state for given feature."""
         states: dict[NodeFeature, Any] = {}

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -227,6 +227,10 @@ class PlugwiseScan(NodeSED):
     # endregion
 
     # region Properties
+    @property
+    def dirty(self) -> bool:
+        """Motion configuration dirty flag."""
+        return self._motion_config.dirty
 
     @property
     def daylight_mode(self) -> bool:
@@ -261,6 +265,7 @@ class PlugwiseScan(NodeSED):
             reset_timer=self.reset_timer,
             daylight_mode=self.daylight_mode,
             sensitivity_level=self.sensitivity_level,
+            dirty=self.dirty,
         )
 
     @property

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -147,9 +147,9 @@ class PlugwiseScan(NodeSED):
 
     async def _load_from_cache(self) -> bool:
         """Load states from previous cached information. Returns True if successful."""
-        LoadSuccess = True
+        super_load_success = True
         if not await super()._load_from_cache():
-            LoadSuccess = False
+            super_load_success = False
         self._motion_state = MotionState(
             state=self._motion_from_cache(),
             timestamp=self._motion_timestamp_from_cache(),
@@ -174,7 +174,7 @@ class PlugwiseScan(NodeSED):
         )
         if dirty:
             await self._scan_configure_update()
-        return LoadSuccess
+        return super_load_success
 
     def _daylight_mode_from_cache(self) -> bool | None:
         """Load awake duration from cache."""

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -62,7 +62,6 @@ DEFAULT_DAYLIGHT_MODE: Final = False
 DEFAULT_FIRMWARE: Final = datetime(2010, 11, 4, 16, 58, 46, tzinfo=UTC)
 
 
-
 # Scan Features
 SCAN_FEATURES: Final = (
     NodeFeature.MOTION,
@@ -445,7 +444,7 @@ class PlugwiseScan(NodeSED):
             self._send,
             self._mac_in_bytes,
             self._motion_config.reset_timer,
-            self._motion_config.sensitivity_value,
+            self._motion_config.sensitivity_level,
             self._motion_config.daylight_mode,
         )
         if (response := await request.send()) is None:

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -433,10 +433,7 @@ class PlugwiseScan(NodeSED):
     async def _run_awake_tasks(self) -> None:
         """Execute all awake tasks."""
         await super()._run_awake_tasks()
-        if (
-                self._scan_config_task_scheduled
-                and await self._configure_scan_task()
-        ):
+        if self._scan_config_task_scheduled and await self._configure_scan_task():
             self._scan_config_task_scheduled = False
 
     async def _configure_scan_task(self) -> bool:

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -9,7 +9,14 @@ from datetime import UTC, datetime
 import logging
 from typing import Any, Final
 
-from ..api import MotionConfig, MotionState, NodeEvent, NodeFeature, NodeType
+from ..api import (
+    MotionConfig,
+    MotionSensitivity,
+    MotionState,
+    NodeEvent,
+    NodeFeature,
+    NodeType,
+)
 from ..connection import StickController
 from ..constants import MAX_UINT_2
 from ..exceptions import MessageError, NodeError, NodeTimeout
@@ -36,16 +43,6 @@ CACHE_SCAN_CONFIG_SENSITIVITY = "scan_sensitivity_level"
 
 # region Defaults for Scan Devices
 
-# Sensitivity values for motion sensor configuration
-HIGH: Final[str] = "HIGH"
-MEDIUM: Final[str] = "MEDIUM"
-OFF: Final[str] = "OFF"
-MOTION_SENSITIVITY: Final[dict] = {
-    HIGH: 20,  # 0x14
-    MEDIUM: 30,  # 0x1E
-    OFF: 255,  # 0xFF
-}
-
 DEFAULT_MOTION_STATE: Final = False
 
 # Time in minutes the motion sensor should not sense motion to
@@ -53,7 +50,7 @@ DEFAULT_MOTION_STATE: Final = False
 DEFAULT_RESET_TIMER: Final = 10
 
 # Default sensitivity of the motion sensors
-DEFAULT_SENSITIVITY = MOTION_SENSITIVITY[MEDIUM]
+DEFAULT_SENSITIVITY = MotionSensitivity.MEDIUM
 
 # Light override
 DEFAULT_DAYLIGHT_MODE: Final = False
@@ -204,9 +201,9 @@ class PlugwiseScan(NodeSED):
     def _sensitivity_level_from_cache(self) -> int | None:
         """Load sensitivity level from cache."""
         if (
-            sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)
+            sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)  # returns level in string CAPITALS
         ) is not None:
-            return int(sensitivity_level)
+            return MotionSensitivity[sensitivity_level]
         return None
 
     def _motion_config_dirty_from_cache(self) -> bool:
@@ -474,7 +471,9 @@ class PlugwiseScan(NodeSED):
             CACHE_SCAN_CONFIG_RESET_TIMER, str(self._motion_config.reset_timer)
         )
         self._set_cache(
-            CACHE_SCAN_CONFIG_SENSITIVITY, self._motion_config.sensitivity_level
+            CACHE_SCAN_CONFIG_SENSITIVITY, str(
+                MotionSensitivity(self._motion_config.sensitivity_level).name
+            )
         )
         self._set_cache(
             CACHE_SCAN_CONFIG_DAYLIGHT_MODE, str(self._motion_config.daylight_mode)

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -446,7 +446,7 @@ class PlugwiseScan(NodeSED):
         """Configure Scan device settings. Returns True if successful."""
         # Default to medium
         sensitivity_value = SENSITIVITY_MAP.get(
-            self._motion_config.sensitivity_level, SENSITIVITY_MEDIUM_VALUE
+            self._motion_config.sensitivity_level, MotionSensitivity.MEDIUM
         )
         request = ScanConfigureRequest(
             self._send,

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -60,9 +60,9 @@ DEFAULT_FIRMWARE: Final = datetime(2010, 11, 4, 16, 58, 46, tzinfo=UTC)
 
 # Sensitivity values for motion sensor configuration
 SENSITIVITY_MAP: Final = {
-    MotionSensitivity.HIGH: 20, # 0x14
-    MotionSensitivity.MEDIUM: 30, # 0x1E
-    MotionSensitivity.OFF: 255, # 0xFF
+    MotionSensitivity.HIGH: 20,  # 0x14
+    MotionSensitivity.MEDIUM: 30,  # 0x1E
+    MotionSensitivity.OFF: 255,  # 0xFF
 }
 
 # Scan Features

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -209,7 +209,7 @@ class PlugwiseScan(NodeSED):
         if (
             sensitivity_level := self._get_cache(CACHE_SCAN_CONFIG_SENSITIVITY)
         ) is not None:
-            return MotionSensitivity([sensitivity_level])
+            return MotionSensitivity[sensitivity_level]
         return None
 
     def _motion_config_dirty_from_cache(self) -> bool:

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -142,9 +142,9 @@ class NodeSED(PlugwiseBaseNode):
 
     async def _load_from_cache(self) -> bool:
         """Load states from previous cached information. Returns True if successful."""
-        LoadSuccess = True
+        super_load_success = True
         if not await super()._load_from_cache():
-            LoadSuccess = False
+            super_load_success = False
         dirty = False
         if (awake_duration := self._awake_duration_from_cache()) is None:
             dirty = True
@@ -174,7 +174,7 @@ class NodeSED(PlugwiseBaseNode):
             await self._sed_configure_update()
         self._awake_timestamp_from_cache()
         self._awake_reason_from_cache()
-        return LoadSuccess
+        return super_load_success
 
     def _awake_duration_from_cache(self) -> int | None:
         """Load awake duration from cache."""

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -327,7 +327,7 @@ class NodeSED(PlugwiseBaseNode):
     # endregion
     # region Properties
     @property
-    def dirty(self) -> int:
+    def dirty(self) -> bool:
         """Battery configuration dirty flag."""
         return self._battery_config.dirty
 

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -191,11 +191,7 @@ class NodeSED(PlugwiseBaseNode):
 
     def _clock_sync_from_cache(self) -> bool | None:
         """Load clock sync state from cache."""
-        if (clock_sync := self._get_cache(CACHE_SED_CLOCK_SYNC)) is not None:
-            if clock_sync == "True":
-                return True
-            return False
-        return None
+        return self._get_cache_as_bool(CACHE_SED_CLOCK_SYNC)
 
     def _maintenance_interval_from_cache(self) -> int | None:
         """Load maintenance interval from cache."""
@@ -222,7 +218,7 @@ class NodeSED(PlugwiseBaseNode):
 
     def _sed_config_dirty_from_cache(self) -> bool:
         """Load battery config dirty  from cache."""
-        if (dirty := self._get_cache(CACHE_SED_DIRTY)) is not None:
+        if (dirty := self._get_cache_as_bool(CACHE_SED_DIRTY)) is not None:
             return dirty
         return True
 

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -2,21 +2,14 @@
 
 from __future__ import annotations
 
-from asyncio import (
-    CancelledError,
-    Future,
-    Task,
-    gather,
-    get_running_loop,
-    wait_for,
-)
+from asyncio import CancelledError, Future, Task, gather, get_running_loop, wait_for
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
 from datetime import datetime, timedelta
 import logging
 from typing import Any, Final
 
-from ..api import BatteryConfig, NodeEvent, NodeFeature, NodeInfo, NodeType
+from ..api import BatteryConfig, NodeEvent, NodeFeature, NodeType
 from ..connection import StickController
 from ..constants import MAX_UINT_2, MAX_UINT_4
 from ..exceptions import MessageError, NodeError
@@ -25,7 +18,6 @@ from ..messages.responses import (
     NODE_AWAKE_RESPONSE_ID,
     NodeAwakeResponse,
     NodeAwakeResponseType,
-    NodeInfoResponse,
     NodeResponseType,
     PlugwiseResponse,
 )
@@ -100,7 +92,7 @@ class NodeSED(PlugwiseBaseNode):
         self._battery_config = BatteryConfig()
         self._new_battery_config = BatteryConfig()
         self._sed_config_task_scheduled = False
-        self._sed_node_info_update_task_scheduled = False 
+        self._sed_node_info_update_task_scheduled = False
 
         self._last_awake: dict[NodeAwakeResponseType, datetime] = {}
         self._last_awake_reason: str = "Unknown"
@@ -618,15 +610,12 @@ class NodeSED(PlugwiseBaseNode):
     async def _run_awake_tasks(self) -> None:
         """Execute all awake tasks."""
         if (
-                self._sed_node_info_update_task_scheduled
-                and await self.node_info_update(None) is not None
+            self._sed_node_info_update_task_scheduled
+            and await self.node_info_update(None) is not None
         ):
             self._sed_node_info_update_task_scheduled = False
 
-        if (
-                self._sed_config_task_scheduled
-                and await self._configure_sed_task()
-        ):
+        if self._sed_config_task_scheduled and await self._configure_sed_task():
             self._sed_config_task_scheduled = False
 
     async def sed_configure(  # pylint: disable=too-many-arguments

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -190,9 +190,6 @@ class NodeSED(PlugwiseBaseNode):
 
     def _clock_sync_from_cache(self) -> bool | None:
         """Load clock sync state from cache."""
-        _LOGGER.debug(
-            "MDI: Bool: %s", str(self._get_cache_as_bool(CACHE_SED_CLOCK_SYNC))
-        )
         return self._get_cache_as_bool(CACHE_SED_CLOCK_SYNC)
 
     def _maintenance_interval_from_cache(self) -> int | None:

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -161,7 +161,7 @@ class NodeSED(PlugwiseBaseNode):
         if (sleep_duration := self._sleep_duration_from_cache()) is None:
             dirty = True
             sleep_duration = SED_DEFAULT_SLEEP_DURATION
-        dirty &= self._sed_config_dirty_from_cache()
+        dirty |= self._sed_config_dirty_from_cache()
         self._battery_config = BatteryConfig(
             awake_duration=awake_duration,
             clock_interval=clock_interval,
@@ -331,7 +331,7 @@ class NodeSED(PlugwiseBaseNode):
     # region Properties
     @property
     def dirty(self) -> int:
-        """Battry configuration dirty flag."""
+        """Battery configuration dirty flag."""
         return self._battery_config.dirty
 
     @property

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -547,7 +547,7 @@ class NodeSED(PlugwiseBaseNode):
 
     async def _run_awake_tasks(self) -> None:
         """Execute all awake tasks."""
-        _LOGGER.debug("_run_awake_tasks | Device %s",self.name)
+        _LOGGER.debug("_run_awake_tasks | Device %s", self.name)
         if (
             self._sed_node_info_update_task_scheduled
             and await self.node_info_update(None) is not None

--- a/plugwise_usb/nodes/sense.py
+++ b/plugwise_usb/nodes/sense.py
@@ -94,10 +94,13 @@ class PlugwiseSense(NodeSED):
         )
         if self._node_info.model is None:
             self._node_info.model = "Sense"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.name is None:
             self._node_info.name = f"Sense {self._node_info.mac[-5:]}"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.firmware is None:
             self._node_info.firmware = DEFAULT_FIRMWARE
+            self._sed_node_info_update_task_scheduled = True
 
     # endregion
 

--- a/plugwise_usb/nodes/switch.py
+++ b/plugwise_usb/nodes/switch.py
@@ -82,10 +82,13 @@ class PlugwiseSwitch(NodeSED):
         await super()._load_defaults()
         if self._node_info.model is None:
             self._node_info.model = "Switch"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.name is None:
             self._node_info.name = f"Switch {self._node_info.mac[-5:]}"
+            self._sed_node_info_update_task_scheduled = True
         if self._node_info.firmware is None:
             self._node_info.firmware = DEFAULT_FIRMWARE
+            self._sed_node_info_update_task_scheduled = True
 
     # endregion
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.10a6"
+version         = "0.44.10"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.10a1"
+version         = "0.44.10a2"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.10a2"
+version         = "0.44.10a3"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.10a0"
+version         = "0.44.10a1"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.9"
+version         = "0.44.10a0"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.10a5"
+version         = "0.44.10a6"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1826,9 +1826,7 @@ class TestStick:
             assert await test_node.set_motion_daylight_mode(True) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert (
-                await test_node.set_motion_sensitivity_level(20) is not None
-            )
+            assert await test_node.set_motion_sensitivity_level(20) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
             assert await test_node.set_motion_reset_timer(5) is not None
@@ -1859,9 +1857,7 @@ class TestStick:
             assert await test_node.set_motion_daylight_mode(True) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert (
-                await test_node.set_motion_sensitivity_level(20) is not None
-            )
+            assert await test_node.set_motion_sensitivity_level(20) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
             assert await test_node.set_motion_reset_timer(5) is not None
@@ -1888,9 +1884,7 @@ class TestStick:
         with pytest.raises(NotImplementedError):
             assert await test_node.set_motion_daylight_mode(True) is not None
         with pytest.raises(NotImplementedError):
-            assert (
-                await test_node.set_motion_sensitivity_level(20) is not None
-            )
+            assert await test_node.set_motion_sensitivity_level(20) is not None
         with pytest.raises(NotImplementedError):
             assert await test_node.set_motion_reset_timer(5) is not None
 
@@ -2229,9 +2223,7 @@ class TestStick:
 
         # test motion sensitivity level
         assert test_scan.sensitivity_level == 30
-        assert (
-            test_scan.motion_config.sensitivity_level == 30
-        )
+        assert test_scan.motion_config.sensitivity_level == 30
         assert not await test_scan.set_motion_sensitivity_level(30)
 
         assert not test_scan.motion_config.dirty

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1834,7 +1834,7 @@ class TestStick:
             await test_node.set_motion_daylight_mode(True)
 
         with pytest.raises(pw_exceptions.NodeError):
-            test_node.set_motion_sensitivity_level(20)
+            await test_node.set_motion_sensitivity_level(20)
 
         with pytest.raises(pw_exceptions.NodeError):
             await test_node.set_motion_reset_timer(5)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1959,12 +1959,6 @@ class TestStick:
             )
         )
 
-        # FIXME NodeInfo Test can be added
-        # sed_node_info = pw_responses.NodeInfoResponse()
-        # sed_node_info.deserialize(
-        #    construct_message(b"0024555555555555555522026A680000000000010000080007004E08459006")
-        # )
-
         sed_config_accepted = pw_responses.NodeResponse()
         sed_config_accepted.deserialize(
             construct_message(b"000000F65555555555555555", b"0000")

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -547,7 +547,7 @@ class TestStick:
                 )
             )
 
-    async def _wait_for_scan(self, stick, timeout: float = 10.0) -> None:
+    async def _wait_for_scan(self, stick) -> None:
         """Wait for scan completion with timeout."""
 
         async def wait_scan_completed():
@@ -555,9 +555,9 @@ class TestStick:
                 await asyncio.sleep(0.1)
 
         try:
-            await asyncio.wait_for(wait_scan_completed(), timeout=timeout)
+            await asyncio.wait_for(wait_scan_completed(), timeout=10)
         except TimeoutError:
-            pytest.fail(f"Scan did not complete within {timeout} seconds")
+            pytest.fail("Scan did not complete within 10 seconds")
 
     @pytest.mark.asyncio
     async def test_stick_node_discovered_subscription(  # noqa: PLR0915

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -332,7 +332,7 @@ class TestStick:
         )
         assert unix_timestamp.serialize() == b"4E08478A"
         with pytest.raises(pw_exceptions.MessageError):
-            assert unix_timestamp.value == dt(2011, 6, 27, 9, 4, 10, tzinfo=UTC)
+            unix_timestamp.value == dt(2011, 6, 27, 9, 4, 10, tzinfo=UTC)
         unix_timestamp.deserialize(b"4E08478A")
         assert unix_timestamp.value == dt(2011, 6, 27, 9, 4, 10, tzinfo=UTC)
 
@@ -343,11 +343,11 @@ class TestStick:
         assert stick.nodes == {}
         assert stick.joined_nodes is None
         with pytest.raises(pw_exceptions.StickError):
-            assert stick.mac_stick
+            stick.mac_stick
         with pytest.raises(pw_exceptions.StickError):
-            assert stick.mac_coordinator
+            stick.mac_coordinator
         with pytest.raises(pw_exceptions.StickError):
-            assert stick.network_id
+            stick.network_id
         assert not stick.network_discovered
         assert not stick.network_state
 
@@ -1910,7 +1910,7 @@ class TestStick:
     async def test_sed_node(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa:  PLR0915
         """Testing properties of SED."""
 
-        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-6-27-8-55-44"
@@ -1973,9 +1973,9 @@ class TestStick:
         assert test_sed.awake_duration == 20
         assert test_sed.battery_config.awake_duration == 20
         with pytest.raises(ValueError):
-            assert await test_sed.set_awake_duration(0)
+            await test_sed.set_awake_duration(0)
         with pytest.raises(ValueError):
-            assert await test_sed.set_awake_duration(256)
+            await test_sed.set_awake_duration(256)
         assert await test_sed.set_awake_duration(10)
         assert test_sed.battery_config.dirty
         assert await test_sed.set_awake_duration(15)
@@ -2016,9 +2016,9 @@ class TestStick:
         assert test_sed.maintenance_interval == 60
         assert test_sed.battery_config.maintenance_interval == 60
         with pytest.raises(ValueError):
-            assert await test_sed.set_maintenance_interval(0)
+            await test_sed.set_maintenance_interval(0)
         with pytest.raises(ValueError):
-            assert await test_sed.set_maintenance_interval(1500)
+            await test_sed.set_maintenance_interval(1500)
         assert not await test_sed.set_maintenance_interval(60)
         assert not test_sed.battery_config.dirty
         assert await test_sed.set_maintenance_interval(30)
@@ -2040,9 +2040,9 @@ class TestStick:
         assert test_sed.clock_interval == 12600
         assert test_sed.battery_config.clock_interval == 12600
         with pytest.raises(ValueError):
-            assert await test_sed.set_clock_interval(0)
+            await test_sed.set_clock_interval(0)
         with pytest.raises(ValueError):
-            assert await test_sed.set_clock_interval(65536)
+            await test_sed.set_clock_interval(65536)
         assert not await test_sed.set_clock_interval(12600)
         assert not test_sed.battery_config.dirty
         assert await test_sed.set_clock_interval(15000)
@@ -2083,9 +2083,9 @@ class TestStick:
         assert test_sed.sleep_duration == 60
         assert test_sed.battery_config.sleep_duration == 60
         with pytest.raises(ValueError):
-            assert await test_sed.set_sleep_duration(0)
+            await test_sed.set_sleep_duration(0)
         with pytest.raises(ValueError):
-            assert await test_sed.set_sleep_duration(65536)
+            await test_sed.set_sleep_duration(65536)
         assert not await test_sed.set_sleep_duration(60)
         assert await test_sed.set_sleep_duration(120)
         assert test_sed.battery_config.dirty
@@ -2106,7 +2106,7 @@ class TestStick:
     async def test_scan_node(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: PLR0915
         """Testing properties of scan."""
 
-        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911 PLR0912
+        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911 PLR0912
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-6-27-8-55-44"
@@ -2179,9 +2179,9 @@ class TestStick:
         assert test_scan.reset_timer == 10
         assert test_scan.motion_config.reset_timer == 10
         with pytest.raises(ValueError):
-            assert await test_scan.set_motion_reset_timer(0)
+            await test_scan.set_motion_reset_timer(0)
         with pytest.raises(ValueError):
-            assert await test_scan.set_motion_reset_timer(256)
+            await test_scan.set_motion_reset_timer(256)
         assert not await test_scan.set_motion_reset_timer(10)
         assert not test_scan.motion_config.dirty
         assert await test_scan.set_motion_reset_timer(15)
@@ -2308,7 +2308,7 @@ class TestStick:
     async def test_switch_node(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Testing properties of switch."""
 
-        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-5-13-7-26-54"
@@ -2411,7 +2411,7 @@ class TestStick:
     ) -> None:
         """Testing discovery of nodes."""
 
-        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-5-13-7-26-54"

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -843,7 +843,7 @@ class TestStick:
 
         # Test non-support relay configuration
         with pytest.raises(pw_exceptions.FeatureError):
-            assert stick.nodes["0098765432101234"].relay_config is not None
+            assert stick.nodes["0098765432101234"].relay_config
         with pytest.raises(pw_exceptions.FeatureError):
             await stick.nodes["0098765432101234"].set_relay_init(True)
         with pytest.raises(pw_exceptions.FeatureError):
@@ -1816,28 +1816,28 @@ class TestStick:
 
         # Validate to raise exception when node is not yet loaded
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5)
 
         with pytest.raises(pw_exceptions.NodeError):
-            test_node.battery_config is not None
+            test_node.battery_config
 
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5)
 
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False)
 
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5)
 
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True)
 
         with pytest.raises(pw_exceptions.NodeError):
-            test_node.set_motion_sensitivity_level(20) is not None
+            test_node.set_motion_sensitivity_level(20)
 
         with pytest.raises(pw_exceptions.NodeError):
-            await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5)
 
         # Validate to raise NotImplementedError calling load() at basenode
         with pytest.raises(NotImplementedError):
@@ -1847,54 +1847,54 @@ class TestStick:
 
         # Validate to raise exception when feature is not supported
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            test_node.battery_config is not None
+            test_node.battery_config
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_motion_sensitivity_level(20) is not None
+            await test_node.set_motion_sensitivity_level(20)
 
         with pytest.raises(pw_exceptions.FeatureError):
-            await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5)
 
         # Add battery feature to test raising not implemented
         # for battery related properties
         test_node._features += (pw_api.NodeFeature.BATTERY,)  # pylint: disable=protected-access
         with pytest.raises(NotImplementedError):
-            await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5)
 
         with pytest.raises(NotImplementedError):
-            test_node.battery_config is not None
+            test_node.battery_config
 
         with pytest.raises(NotImplementedError):
-            await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5)
 
         with pytest.raises(NotImplementedError):
-            await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False)
 
         with pytest.raises(NotImplementedError):
-            await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5)
 
         test_node._features += (pw_api.NodeFeature.MOTION,)  # pylint: disable=protected-access
         with pytest.raises(NotImplementedError):
-            await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True)
         with pytest.raises(NotImplementedError):
-            await test_node.set_motion_sensitivity_level(20) is not None
+            await test_node.set_motion_sensitivity_level(20)
         with pytest.raises(NotImplementedError):
-            await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5)
 
         assert not test_node.cache_enabled
         assert test_node.mac == "1298347650AFBECD"

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -332,7 +332,7 @@ class TestStick:
         )
         assert unix_timestamp.serialize() == b"4E08478A"
         with pytest.raises(pw_exceptions.MessageError):
-            unix_timestamp.value == dt(2011, 6, 27, 9, 4, 10, tzinfo=UTC)
+            unix_timestamp.value
         unix_timestamp.deserialize(b"4E08478A")
         assert unix_timestamp.value == dt(2011, 6, 27, 9, 4, 10, tzinfo=UTC)
 
@@ -501,7 +501,7 @@ class TestStick:
 
     async def node_awake(self, event: pw_api.NodeEvent, mac: str) -> None:  # type: ignore[name-defined]
         """Handle awake event callback."""
-        _LOGGER.debug("Node %s has even %s", mac, str(pw_api.NodeEvent))
+        _LOGGER.debug("Node %s has event %s", mac, str(pw_api.NodeEvent))
         if event == pw_api.NodeEvent.AWAKE:
             self.test_node_awake.set_result(mac)
         else:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -843,7 +843,7 @@ class TestStick:
 
         # Test non-support relay configuration
         with pytest.raises(pw_exceptions.FeatureError):
-            assert stick.nodes["0098765432101234"].relay_config
+            stick.nodes["0098765432101234"].relay_config
         with pytest.raises(pw_exceptions.FeatureError):
             await stick.nodes["0098765432101234"].set_relay_init(True)
         with pytest.raises(pw_exceptions.FeatureError):
@@ -1903,7 +1903,7 @@ class TestStick:
     async def test_sed_node(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa:  PLR0915
         """Testing properties of SED."""
 
-        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-6-27-8-55-44"
@@ -1915,18 +1915,22 @@ class TestStick:
                 return "20"
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
                 return "12600"
-            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
-                return False
-            if setting == pw_sed.CACHE_SED_DIRTY:
-                return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
                 return "60"
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
                 return "60"
             return None
 
+        def fake_cache_bool(dummy: object, setting: str) -> bool | None:
+            """Fake cache_bool retrieval."""
+            if setting in (pw_sed.CACHE_SED_CLOCK_SYNC, pw_sed.CACHE_SED_DIRTY):
+                return False
+            return None
+
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
-        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache)
+        monkeypatch.setattr(
+            pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache_bool
+        )
         mock_stick_controller = MockStickController()
 
         async def load_callback(event: pw_api.NodeEvent, mac: str) -> None:  # type: ignore[name-defined]
@@ -2099,7 +2103,7 @@ class TestStick:
     async def test_scan_node(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: PLR0915
         """Testing properties of scan."""
 
-        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911 PLR0912
+        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911 PLR0912
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-6-27-8-55-44"
@@ -2113,30 +2117,36 @@ class TestStick:
                 return "20"
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
                 return "12600"
-            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
-                return True
-            if setting == pw_sed.CACHE_SED_DIRTY:
-                return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
                 return "60"
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
                 return "60"
-            if setting == pw_scan.CACHE_SCAN_MOTION_STATE:
-                return False
             if setting == pw_scan.CACHE_SCAN_MOTION_TIMESTAMP:
                 return "2024-12-6-1-0-0"
             if setting == pw_scan.CACHE_SCAN_CONFIG_RESET_TIMER:
                 return "10"
             if setting == pw_scan.CACHE_SCAN_CONFIG_SENSITIVITY:
                 return "MEDIUM"
-            if setting == pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE:
+            return None
+
+        def fake_cache_bool(dummy: object, setting: str) -> bool | None:
+            """Fake cache_bool retrieval."""
+            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
+                return True
+            if setting == pw_sed.CACHE_SED_DIRTY:
                 return False
-            if setting == pw_scan.CACHE_SCAN_CONFIG_DIRTY:
+            if setting in (
+                pw_scan.CACHE_SCAN_MOTION_STATE,
+                pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE,
+                pw_scan.CACHE_SCAN_CONFIG_DIRTY,
+            ):
                 return False
             return None
 
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
-        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache)
+        monkeypatch.setattr(
+            pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache_bool
+        )
         mock_stick_controller = MockStickController()
         scan_config_accepted = pw_responses.NodeAckResponse()
         scan_config_accepted.deserialize(
@@ -2294,7 +2304,7 @@ class TestStick:
     async def test_switch_node(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Testing properties of switch."""
 
-        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-5-13-7-26-54"
@@ -2308,18 +2318,22 @@ class TestStick:
                 return "15"
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
                 return "14600"
-            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
-                return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
                 return "900"
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
                 return "180"
-            if setting == pw_sed.CACHE_SED_DIRTY:
+            return None
+
+        def fake_cache_bool(dummy: object, setting: str) -> bool | None:
+            """Fake cache_bool retrieval."""
+            if setting in (pw_sed.CACHE_SED_CLOCK_SYNC, pw_sed.CACHE_SED_DIRTY):
                 return False
             return None
 
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
-        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache)
+        monkeypatch.setattr(
+            pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache_bool
+        )
         mock_stick_controller = MockStickController()
 
         async def load_callback(event: pw_api.NodeEvent, mac: str) -> None:  # type: ignore[name-defined]
@@ -2397,7 +2411,7 @@ class TestStick:
     ) -> None:
         """Testing discovery of nodes."""
 
-        def fake_cache(dummy: object, setting: str) -> str | bool | None:  # noqa: PLR0911
+        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
             """Fake cache retrieval."""
             if setting == pw_node.CACHE_FIRMWARE:
                 return "2011-5-13-7-26-54"
@@ -2411,18 +2425,22 @@ class TestStick:
                 return "10"
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
                 return "25200"
-            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
-                return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
                 return "60"
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
                 return "60"
-            if setting == pw_sed.CACHE_SED_DIRTY:
+            return None
+
+        def fake_cache_bool(dummy: object, setting: str) -> bool | None:
+            """Fake cache_bool retrieval."""
+            if setting in (pw_sed.CACHE_SED_CLOCK_SYNC, pw_sed.CACHE_SED_DIRTY):
                 return False
             return None
 
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
-        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache)
+        monkeypatch.setattr(
+            pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache_bool
+        )
         mock_serial = MockSerial(None)
         monkeypatch.setattr(
             pw_connection_manager,

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1808,28 +1808,28 @@ class TestStick:
 
         # Validate to raise exception when node is not yet loaded
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert test_node.battery_config is not None
+            test_node.battery_config is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_motion_sensitivity_level(20) is not None
+            test_node.set_motion_sensitivity_level(20) is not None
 
         with pytest.raises(pw_exceptions.NodeError):
-            assert await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5) is not None
 
         # Validate to raise NotImplementedError calling load() at basenode
         with pytest.raises(NotImplementedError):
@@ -1839,54 +1839,54 @@ class TestStick:
 
         # Validate to raise exception when feature is not supported
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert test_node.battery_config is not None
+            test_node.battery_config is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_motion_sensitivity_level(20) is not None
+            await test_node.set_motion_sensitivity_level(20) is not None
 
         with pytest.raises(pw_exceptions.FeatureError):
-            assert await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5) is not None
 
         # Add battery feature to test raising not implemented
         # for battery related properties
         test_node._features += (pw_api.NodeFeature.BATTERY,)  # pylint: disable=protected-access
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_awake_duration(5) is not None
+            await test_node.set_awake_duration(5) is not None
 
         with pytest.raises(NotImplementedError):
-            assert test_node.battery_config is not None
+            test_node.battery_config is not None
 
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_clock_interval(5) is not None
+            await test_node.set_clock_interval(5) is not None
 
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_clock_sync(False) is not None
+            await test_node.set_clock_sync(False) is not None
 
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_sleep_duration(5) is not None
+            await test_node.set_sleep_duration(5) is not None
 
         test_node._features += (pw_api.NodeFeature.MOTION,)  # pylint: disable=protected-access
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_motion_daylight_mode(True) is not None
+            await test_node.set_motion_daylight_mode(True) is not None
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_motion_sensitivity_level(20) is not None
+            await test_node.set_motion_sensitivity_level(20) is not None
         with pytest.raises(NotImplementedError):
-            assert await test_node.set_motion_reset_timer(5) is not None
+            await test_node.set_motion_reset_timer(5) is not None
 
         assert not test_node.cache_enabled
         assert test_node.mac == "1298347650AFBECD"

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1912,7 +1912,7 @@ class TestStick:
                 return "6"
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
-            if setting == pw_sed.CACHE_AWAKE_DURATION:
+            if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
                 return "20"
             if setting == pw_sed.CACHE_CLOCK_INTERVAL:
                 return "12600"
@@ -2115,7 +2115,7 @@ class TestStick:
                 return "True"
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
-            if setting == pw_sed.CACHE_AWAKE_DURATION:
+            if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
                 return "20"
             if setting == pw_sed.CACHE_CLOCK_INTERVAL:
                 return "12600"
@@ -2125,16 +2125,18 @@ class TestStick:
                 return "43200"
             if setting == pw_sed.CACHE_SLEEP_DURATION:
                 return "120"
-            if setting == pw_scan.CACHE_MOTION_STATE:
+            if setting == pw_scan.CACHE_SCAN_MOTION_STATE:
                 return "False"
-            if setting == pw_scan.CACHE_MOTION_TIMESTAMP:
+            if setting == pw_scan.CACHE_SCAN_MOTION_TIMESTAMP:
                 return "2024-12-6-1-0-0"
-            if setting == pw_scan.CACHE_MOTION_RESET_TIMER:
+            if setting == pw_scan.CACHE_SCAN_CONFIG_RESET_TIMER:
                 return "10"
-            if setting == pw_scan.CACHE_SCAN_SENSITIVITY:
+            if setting == pw_scan.CACHE_SCAN_CONFIG_SENSITIVITY:
                 return "MEDIUM"
-            if setting == pw_scan.CACHE_SCAN_DAYLIGHT_MODE:
+            if setting == pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE:
                 return "True"
+            if setting == pw_scan.CACHE_SCAN_CONFIG_DIRTY:
+                return "False"
             return None
 
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
@@ -2192,7 +2194,6 @@ class TestStick:
         mock_stick_controller.send_response = scan_config_failed
         await test_scan._awake_response(awake_response1)  # pylint: disable=protected-access
         await asyncio.sleep(0.001)  # Ensure time for task to be executed
-        assert not test_scan.scan_config_task_scheduled
 
         # Successful config
         awake_response2 = pw_responses.NodeAwakeResponse()
@@ -2314,16 +2315,18 @@ class TestStick:
                 return "2024-12-7-1-0-0"
             if setting == pw_node.CACHE_RELAY:
                 return "True"
-            if setting == pw_sed.CACHE_AWAKE_DURATION:
+            if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
                 return "15"
-            if setting == pw_sed.CACHE_CLOCK_INTERVAL:
+            if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
                 return "14600"
-            if setting == pw_sed.CACHE_CLOCK_SYNC:
+            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
                 return "False"
-            if setting == pw_sed.CACHE_MAINTENANCE_INTERVAL:
+            if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
                 return "900"
-            if setting == pw_sed.CACHE_SLEEP_DURATION:
+            if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
                 return "180"
+            if setting == pw_sed.CACHE_SED_DIRTY:
+                return "False"
             return None
 
         monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -2110,23 +2110,23 @@ class TestStick:
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
             if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
-                return 20
+                return "20"
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
-                return 12600
+                return "12600"
             if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
                 return True
             if setting == pw_sed.CACHE_SED_DIRTY:
                 return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
-                return 60
+                return "60"
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
-                return 60
+                return "60"
             if setting == pw_scan.CACHE_SCAN_MOTION_STATE:
                 return False
             if setting == pw_scan.CACHE_SCAN_MOTION_TIMESTAMP:
                 return "2024-12-6-1-0-0"
             if setting == pw_scan.CACHE_SCAN_CONFIG_RESET_TIMER:
-                return 10
+                return "10"
             if setting == pw_scan.CACHE_SCAN_CONFIG_SENSITIVITY:
                 return "MEDIUM"
             if setting == pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -2417,6 +2417,33 @@ class TestStick:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Testing discovery of nodes."""
+
+        def fake_cache(dummy: object, setting: str) -> str | None:  # noqa: PLR0911
+            """Fake cache retrieval."""
+            if setting == pw_node.CACHE_FIRMWARE:
+                return "2011-5-13-7-26-54"
+            if setting == pw_node.CACHE_HARDWARE:
+                return "080029"
+            if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
+                return "2024-12-7-1-0-0"
+            if setting == pw_node.CACHE_RELAY:
+                return "True"
+            if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
+                return "10"
+            if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
+                return "25200"
+            if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
+                return False
+            if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
+                return "60"
+            if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
+                return "60"
+            if setting == pw_sed.CACHE_SED_DIRTY:
+                return False
+            return None
+
+        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache", fake_cache)
+        monkeypatch.setattr(pw_node.PlugwiseBaseNode, "_get_cache_as_bool", fake_cache)
         mock_serial = MockSerial(None)
         monkeypatch.setattr(
             pw_connection_manager,

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -501,7 +501,7 @@ class TestStick:
 
     async def node_awake(self, event: pw_api.NodeEvent, mac: str) -> None:  # type: ignore[name-defined]
         """Handle awake event callback."""
-        _LOGGER.debug("Node %s has event %s", mac, str(pw_api.NodeEvent))
+        _LOGGER.debug("Node %s has event %s", mac, str(event))
         if event == pw_api.NodeEvent.AWAKE:
             self.test_node_awake.set_result(mac)
         else:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -575,7 +575,6 @@ class TestStick:
         # Inject NodeAwakeResponse message to trigger a 'node discovered' event
         mock_serial.inject_message(b"004F555555555555555500", b"FFFE")
         mac_awake_node = await self.test_node_awake
-        mac_awake_node = "5555555555555555"
         assert mac_awake_node == "5555555555555555"
         unsub_awake()
 

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -2126,7 +2126,7 @@ class TestStick:
             if setting == pw_scan.CACHE_SCAN_CONFIG_RESET_TIMER:
                 return 10
             if setting == pw_scan.CACHE_SCAN_CONFIG_SENSITIVITY:
-                return 30
+                return "MEDIUM"
             if setting == pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE:
                 return False
             if setting == pw_scan.CACHE_SCAN_CONFIG_DIRTY:

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1827,10 +1827,7 @@ class TestStick:
 
         with pytest.raises(pw_exceptions.NodeError):
             assert (
-                await test_node.set_motion_sensitivity_level(
-                    pw_api.MotionSensitivity.HIGH
-                )
-                is not None
+                await test_node.set_motion_sensitivity_level(20) is not None
             )
 
         with pytest.raises(pw_exceptions.NodeError):
@@ -1863,10 +1860,7 @@ class TestStick:
 
         with pytest.raises(pw_exceptions.FeatureError):
             assert (
-                await test_node.set_motion_sensitivity_level(
-                    pw_api.MotionSensitivity.HIGH
-                )
-                is not None
+                await test_node.set_motion_sensitivity_level(20) is not None
             )
 
         with pytest.raises(pw_exceptions.FeatureError):
@@ -1895,10 +1889,7 @@ class TestStick:
             assert await test_node.set_motion_daylight_mode(True) is not None
         with pytest.raises(NotImplementedError):
             assert (
-                await test_node.set_motion_sensitivity_level(
-                    pw_api.MotionSensitivity.HIGH
-                )
-                is not None
+                await test_node.set_motion_sensitivity_level(20) is not None
             )
         with pytest.raises(NotImplementedError):
             assert await test_node.set_motion_reset_timer(5) is not None
@@ -2117,25 +2108,25 @@ class TestStick:
             if setting == pw_node.CACHE_NODE_INFO_TIMESTAMP:
                 return "2024-12-7-1-0-0"
             if setting == pw_sed.CACHE_SED_AWAKE_DURATION:
-                return "20"
+                return 20
             if setting == pw_sed.CACHE_SED_CLOCK_INTERVAL:
-                return "12600"
+                return 12600
             if setting == pw_sed.CACHE_SED_CLOCK_SYNC:
                 return True
             if setting == pw_sed.CACHE_SED_DIRTY:
                 return False
             if setting == pw_sed.CACHE_SED_MAINTENANCE_INTERVAL:
-                return "60"
+                return 60
             if setting == pw_sed.CACHE_SED_SLEEP_DURATION:
-                return "60"
+                return 60
             if setting == pw_scan.CACHE_SCAN_MOTION_STATE:
                 return False
             if setting == pw_scan.CACHE_SCAN_MOTION_TIMESTAMP:
                 return "2024-12-6-1-0-0"
             if setting == pw_scan.CACHE_SCAN_CONFIG_RESET_TIMER:
-                return "10"
+                return 10
             if setting == pw_scan.CACHE_SCAN_CONFIG_SENSITIVITY:
-                return "MEDIUM"
+                return 30
             if setting == pw_scan.CACHE_SCAN_CONFIG_DAYLIGHT_MODE:
                 return False
             if setting == pw_scan.CACHE_SCAN_CONFIG_DIRTY:
@@ -2237,17 +2228,14 @@ class TestStick:
         assert test_scan.motion_config.daylight_mode
 
         # test motion sensitivity level
-        assert test_scan.sensitivity_level == pw_api.MotionSensitivity.MEDIUM
+        assert test_scan.sensitivity_level == 30
         assert (
-            test_scan.motion_config.sensitivity_level == pw_api.MotionSensitivity.MEDIUM
+            test_scan.motion_config.sensitivity_level == 30
         )
-        assert not await test_scan.set_motion_sensitivity_level(
-            pw_api.MotionSensitivity.MEDIUM
-        )
+        assert not await test_scan.set_motion_sensitivity_level(30)
+
         assert not test_scan.motion_config.dirty
-        assert await test_scan.set_motion_sensitivity_level(
-            pw_api.MotionSensitivity.HIGH
-        )
+        assert await test_scan.set_motion_sensitivity_level(20)
         assert test_scan.motion_config.dirty
         awake_response4 = pw_responses.NodeAwakeResponse()
         awake_response4.deserialize(
@@ -2259,10 +2247,8 @@ class TestStick:
         await test_scan._awake_response(awake_response4)  # pylint: disable=protected-access
         await asyncio.sleep(0.001)  # Ensure time for task to be executed
         assert not test_scan.motion_config.dirty
-        assert test_scan.sensitivity_level == pw_api.MotionSensitivity.HIGH
-        assert (
-            test_scan.motion_config.sensitivity_level == pw_api.MotionSensitivity.HIGH
-        )
+        assert test_scan.sensitivity_level == 20
+        assert test_scan.motion_config.sensitivity_level == 20
 
         # scan with cache enabled
         mock_stick_controller.send_response = None

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -548,7 +548,7 @@ class TestStick:
             )
 
     @pytest.mark.asyncio
-    async def test_stick_node_discovered_subscription(
+    async def test_stick_node_discovered_subscription(  # noqa: PLR0915
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Testing "new_node" subscription for Scan."""
@@ -2644,14 +2644,7 @@ class TestStick:
         # endregion
 
         # region Switch
-        self.test_node_loaded = asyncio.Future()
-        unsub_loaded = stick.subscribe_to_node_events(
-            node_event_callback=self.node_loaded,
-            events=(pw_api.NodeEvent.LOADED,),
-        )
         mock_serial.inject_message(b"004F888888888888888800", b"FFFE")
-        assert await self.test_node_loaded
-        unsub_loaded()
 
         assert stick.nodes["8888888888888888"].node_info.firmware == dt(
             2011, 6, 27, 9, 4, 10, tzinfo=UTC


### PR DESCRIPTION
Improve C+ registry collection and node discovery
- remove unused C+ registry address propagation to the nodes
- call discover_node for all cached nodes during startup
- C+ scanning pace is determined by the size of cached (<4 nodes)
Improve handling of SED and Scan configuration data
- Remove _new_ variables
- Add dirty flag when configuration has changed but node has not been awake yet
- Improve handling of default values when cache is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SED and SCAN devices now use a durable "dirty" flag to track and apply pending configuration changes; registry and discovery operate by MAC addresses only; cache pruning added.

* **Bug Fixes**
  * Improved Circle+ registry collection and node discovery reliability.

* **Refactor**
  * Simplified and unified node/registry discovery, scanning and configuration flows; standardized cache keys.

* **Tests**
  * Tests updated to await scan completion, updated expectations and cache-related assertions.

* **Documentation**
  * Added new changelog entry for v0.44.10.

* **Chores**
  * Package version bumped to 0.44.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->