### PR TITLE
Improve EnergyLogs collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Improve energy-collection via PR [311](https://github.com/plugwise/python-plugwise-usb/pull/311)
+
 ## v0.44.10 - 2025-08-11
 
 - PR [302](https://github.com/plugwise/python-plugwise-usb/pull/302) Improve registry discovery and SED/SCAN configuration management

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -461,7 +461,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             "Start collecting today's energy logs for node %s.",
             self._mac_in_str,
         )
-        total_addresses = min(MAX_LOG_HOURS / 2, datetime.now(tz=UTC).hour + 1)
+        total_addresses = min(int(MAX_LOG_HOURS / 2), datetime.now(tz=UTC).hour + 1)
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -469,7 +469,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)
             if not result:
-                # Handle case with None-data in all address slots
+                # Stop initial log collection when an address contains no (None) or outdated data
+                # Outdated data can indicate a EnergyLog address rollover: from address 6014 to 0
                 _LOGGER.debug(
                     "All slots at log address %s are empty or outdated – stopping initial collection",
                     log_address,

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -560,7 +560,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             if (
                 log_timestamp is None
                 or log_pulses is None
-                # Don't store an old log record; store am empty record instead
+                # Don't store an old log record; store an empty record instead
                 or not self._check_timestamp_is_recent(address, _slot, log_timestamp)
             ):
                 self._energy_counters.add_empty_log(response.log_address, _slot)
@@ -587,10 +587,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
     def _check_timestamp_is_recent(
         self, address: int, slot: int, timestamp: datetime
     ) -> bool:
-        """Check if the timestamp of the received log-record is recent.
-
-        A timestamp newer than MAX_LOG_HOURS is considered recent.
-        """
+        """Check if a log record timestamp is within the last MAX_LOG_HOURS hours."""
         age_seconds = (
             datetime.now(tz=UTC) - timestamp.replace(tzinfo=UTC)
         ).total_seconds()

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -541,7 +541,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
         # Forward historical energy log information to energy counters
         # Each response message contains 4 log counters (slots) of the
         # energy pulses collected during the previous hour of given timestamp
-        last_energy_timestamp_collected = False
         for _slot in range(4, 0, -1):
             log_timestamp, log_pulses = response.log_data[_slot]
             _LOGGER.debug(

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -74,6 +74,7 @@ CIRCLE_FEATURES: Final = (
 DEFAULT_FIRMWARE: Final = datetime(2008, 8, 26, 15, 46, tzinfo=UTC)
 
 MAX_LOG_HOURS = DAY_IN_HOURS
+MAX_ADDRESSES_COLLECTED: Final = 11
 
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 _LOGGER = logging.getLogger(__name__)
@@ -461,7 +462,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             "Start collecting today's energy logs for node %s.",
             self._mac_in_str,
         )
-        total_addresses = min(11, datetime.now(tz=UTC).hour + 1)
+        total_addresses = min(MAX_ADDRESSES_COLLECTED, datetime.now(tz=UTC).hour + 1)
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from functools import wraps
 import logging
+from math import floor
 from typing import Any, Final, TypeVar, cast
 
 from ..api import (
@@ -463,7 +464,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             "Start collecting initial energy logs from the last 10 log addresses for node %s.",
             self._mac_in_str,
         )
-        total_addresses = 11
+        total_addresses = int(floor(datetime.now(tz=UTC).hour / 4) + 1)
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -461,7 +461,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             return
 
         _LOGGER.debug(
-            "Start collecting initial energy logs from the last 10 log addresses for node %s.",
+            "Start collecting today's energy logs for node %s.",
             self._mac_in_str,
         )
         total_addresses = int(floor(datetime.now(tz=UTC).hour / 4) + 1)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -506,8 +506,12 @@ class PlugwiseCircle(PlugwiseBaseNode):
             result = await task
             # When an energy log collection task returns False, stop and cancel the remaining tasks
             if not result:
-                for t in tasks[idx + 1 :]:
+                to_cancel = tasks[idx + 1 :]
+                for t in to_cancel:
                     t.cancel()
+                # Drain cancellations to avoid "Task exception was never retrieved"
+                from asyncio import gather as _gather
+                await _gather(*to_cancel, return_exceptions=True)
                 break
 
         if self._cache_enabled:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -75,7 +75,6 @@ CIRCLE_FEATURES: Final = (
 DEFAULT_FIRMWARE: Final = datetime(2008, 8, 26, 15, 46, tzinfo=UTC)
 
 MAX_LOG_HOURS = DAY_IN_HOURS
-MAX_ADDRESSES_COLLECTED: Final = 11
 
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 _LOGGER = logging.getLogger(__name__)
@@ -455,7 +454,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
         return None
 
     async def _get_initial_energy_logs(self) -> None:
-        """Collect initial energy logs for the hours elapsed today up to MAX_LOG_HOURS ."""
+        """Collect initial energy logs for the hours elapsed today up to MAX_LOG_HOURS."""
         if self._current_log_address is None:
             return
 
@@ -469,8 +468,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
 
         # When only consumption is measured, 1 address contains data from 4 hours
         # When both consumption and production are measured, 1 address contains data from 2 hours
-        factor = 4 if self.energy_production_interval is not None else 2
-        max_addresses_to_collect = int(MAX_LOG_HOURS / factor)
+        factor = 4 if self.energy_production_interval is None else 2
+        max_addresses_to_collect = MAX_LOG_HOURS // factor
         total_addresses = min(
             max_addresses_to_collect, ceil(datetime.now(tz=UTC).hour / factor) + 1
         )

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -468,7 +468,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
 
         # When only consumption is measured, 1 address contains data from 4 hours
         # When both consumption and production are measured, 1 address contains data from 2 hours
-        factor = 4 if self.energy_production_interval is None else 2
+        cons_only = self.energy_production_interval is None
+        factor = 4 if cons_only else 2
         max_addresses_to_collect = MAX_LOG_HOURS // factor
         total_addresses = min(
             max_addresses_to_collect, ceil(datetime.now(tz=UTC).hour / factor) + 1

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -24,6 +24,7 @@ from ..api import (
 )
 from ..connection import StickController
 from ..constants import (
+    DAY_IN_HOURS,
     DEFAULT_CONS_INTERVAL,
     MAX_TIME_DRIFT,
     MINIMAL_POWER_UPDATE,
@@ -71,6 +72,8 @@ CIRCLE_FEATURES: Final = (
 
 # Default firmware if not known
 DEFAULT_FIRMWARE: Final = datetime(2008, 8, 26, 15, 46, tzinfo=UTC)
+
+MAX_LOG_HOURS = DAY_IN_HOURS
 
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 _LOGGER = logging.getLogger(__name__)
@@ -468,7 +471,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             if not result:
                 # Handle case with None-data in all address slots
                 _LOGGER.debug(
-                     "All slots at log address %s are empty or outdated – stopping initial collection",
+                    "All slots at log address %s are empty or outdated – stopping initial collection",
                     log_address,
                 )
                 break
@@ -580,12 +583,12 @@ class PlugwiseCircle(PlugwiseBaseNode):
     ) -> bool:
         """Check if the timestamp of the received log-record is recent.
 
-        A timestamp from within the last 24 hours is considered recent.
+        A timestamp newer than MAX_LOG_HOURS is considered recent.
         """
         age_seconds = (
             datetime.now(tz=UTC) - timestamp.replace(tzinfo=UTC)
         ).total_seconds()
-        if age_seconds > DAY_IN_HOURS * 3600:
+        if age_seconds > MAX_LOG_HOURS * 3600:
             _LOGGER.warning(
                 "EnergyLog from Node %s | address %s | slot %s | timestamp %s is outdated, ignoring...",
                 self._mac_in_str,

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from asyncio import Task, create_task
+from asyncio import Task, create_task, gather
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -510,9 +510,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 for t in to_cancel:
                     t.cancel()
                 # Drain cancellations to avoid "Task exception was never retrieved"
-                from asyncio import gather as _gather
-
-                await _gather(*to_cancel, return_exceptions=True)
+                await gather(*to_cancel, return_exceptions=True)
                 break
 
         if self._cache_enabled:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -544,33 +544,33 @@ class PlugwiseCircle(PlugwiseBaseNode):
             if (
                 log_timestamp is None
                 or log_pulses is None
-                # Don't store an old log-record, store am empty record instead
+                # Don't store an old log-record; store am empty record instead
                 or not self._check_timestamp_is_recent(address, _slot, log_timestamp)
             ):
                 self._energy_counters.add_empty_log(response.log_address, _slot)
                 continue
 
-            if await self._energy_log_record_update_state(
+            await self._energy_log_record_update_state(
                 response.log_address,
                 _slot,
                 log_timestamp.replace(tzinfo=UTC),
                 log_pulses,
                 import_only=True,
-            ):
-                any_record_stored = True
-                if not last_energy_timestamp_collected:
-                    # Collect the timestamp of the most recent response
-                    self._last_collected_energy_timestamp = log_timestamp.replace(
-                        tzinfo=UTC
-                    )
-                    _LOGGER.debug(
-                        "Setting last_collected_energy_timestamp to %s",
-                        self._last_collected_energy_timestamp,
-                    )
-                    last_energy_timestamp_collected = True
+            )
+            any_record_stored = True
+            if not last_energy_timestamp_collected:
+                # Collect the timestamp of the most recent response
+                self._last_collected_energy_timestamp = log_timestamp.replace(
+                    tzinfo=UTC
+                )
+                _LOGGER.debug(
+                    "Setting last_collected_energy_timestamp to %s",
+                    self._last_collected_energy_timestamp,
+                )
+                last_energy_timestamp_collected = True
 
         self._energy_counters.update()
-        if any_record_stored:
+        if any_record_stored and self._cache_enabled:
             _LOGGER.debug(
                 "Saving energy record update to cache for %s", self._mac_in_str
             )

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -502,12 +502,13 @@ class PlugwiseCircle(PlugwiseBaseNode):
             create_task(self.energy_log_update(address))
             for address in missing_addresses
         ]
-        for task in tasks:
-            await task
-            # When an energy log collection task returns False, do not execute the remaining tasks
-            if not task.result():
-                for t in tasks:
+        for idx, task in enumerate(tasks):
+            result = await task
+            # When an energy log collection task returns False, stop and cancel the remaining tasks
+            if not result:
+                for t in tasks[idx + 1 :]:
                     t.cancel()
+                break
 
         if self._cache_enabled:
             await self._energy_log_records_save_to_cache()

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -453,7 +453,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
         return None
 
     async def _get_initial_energy_logs(self) -> None:
-        """Collect initial energy logs for recent hours up to MAX_LOG_HOURS/2 (or hours elapsed today)."""
+        """Collect initial energy logs for up to 10 last log addresses or from the hours elapsed today."""
         if self._current_log_address is None:
             return
 
@@ -461,7 +461,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             "Start collecting today's energy logs for node %s.",
             self._mac_in_str,
         )
-        total_addresses = min(int(MAX_LOG_HOURS / 2), datetime.now(tz=UTC).hour + 1)
+        total_addresses = min(11, datetime.now(tz=UTC).hour + 1)
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -471,7 +471,9 @@ class PlugwiseCircle(PlugwiseBaseNode):
         # When both consumption and production are measured, 1 address contains data from 2 hours
         factor = 4 if self.energy_production_interval is not None else 2
         max_addresses_to_collect = int(MAX_LOG_HOURS / factor)
-        total_addresses = min(max_addresses_to_collect, ceil(datetime.now(tz=UTC).hour / factor) + 1)
+        total_addresses = min(
+            max_addresses_to_collect, ceil(datetime.now(tz=UTC).hour / factor) + 1
+        )
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from functools import wraps
 import logging
-from match import ceil
+from math import ceil
 from typing import Any, Final, TypeVar, cast
 
 from ..api import (

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -465,7 +465,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
         )
         total_addresses = 11
         log_address = self._current_log_address
-        prev_address_timestamp: datetime | None = None
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)
             if not result:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -511,6 +511,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     t.cancel()
                 # Drain cancellations to avoid "Task exception was never retrieved"
                 from asyncio import gather as _gather
+
                 await _gather(*to_cancel, return_exceptions=True)
                 break
 

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -453,7 +453,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
         return None
 
     async def _get_initial_energy_logs(self) -> None:
-        """Collect initial energy logs from the last 10 log addresses."""
+        """Collect initial energy logs for recent hours up to MAX_LOG_HOURS/2 (or hours elapsed today)."""
         if self._current_log_address is None:
             return
 
@@ -547,7 +547,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             if (
                 log_timestamp is None
                 or log_pulses is None
-                # Don't store an old log-record; store am empty record instead
+                # Don't store an old log record; store am empty record instead
                 or not self._check_timestamp_is_recent(address, _slot, log_timestamp)
             ):
                 self._energy_counters.add_empty_log(response.log_address, _slot)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -8,7 +8,6 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from functools import wraps
 import logging
-from math import floor
 from typing import Any, Final, TypeVar, cast
 
 from ..api import (
@@ -462,7 +461,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
             "Start collecting today's energy logs for node %s.",
             self._mac_in_str,
         )
-        total_addresses = int(floor(datetime.now(tz=UTC).hour / 4) + 1)
+        total_addresses = min(MAX_LOG_HOURS / 2, datetime.now(tz=UTC).hour + 1)
         log_address = self._current_log_address
         while total_addresses > 0:
             result = await self.energy_log_update(log_address)

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -118,7 +118,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
         self._energy_counters = EnergyCounters(mac)
         self._retrieve_energy_logs_task: None | Task[None] = None
         self._last_energy_log_requested: bool = False
-        self._last_collected_energy_timestamp: datetime | None = None
 
         self._group_member: list[int] = []
 
@@ -562,16 +561,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 import_only=True,
             )
             any_record_stored = True
-            if not last_energy_timestamp_collected:
-                # Collect the timestamp of the most recent response
-                self._last_collected_energy_timestamp = log_timestamp.replace(
-                    tzinfo=UTC
-                )
-                _LOGGER.debug(
-                    "Setting last_collected_energy_timestamp to %s",
-                    self._last_collected_energy_timestamp,
-                )
-                last_energy_timestamp_collected = True
 
         self._energy_counters.update()
         if any_record_stored and self._cache_enabled:


### PR DESCRIPTION
Don't store energy-log data when it's outside the time-interval of interest (MAX_LOG_HOURS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Energy logs now enforce a time-based recency threshold and store only recent, non-empty records.
  * Startup collection adapts to the current hour and is capped to reduce requests and speed initial log gathering.

* **Reliability**
  * Collection unified to a single success outcome; ongoing collection halts on failure, remaining tasks cancel early, and cache updates occur only when new records were stored.

* **Documentation**
  * Changelog updated with an "Ongoing" note referencing the energy-collection improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->