### PR TITLE
allow get_state request for non-data NodeFeatures

### DIFF
--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -1294,7 +1294,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     )
                 case _:
                     state_result = await super().get_state((feature,))
-                    states[feature] = state_result[feature]
+                    if feature in state_result:
+                        states[feature] = state_result[feature]
 
         if NodeFeature.AVAILABLE not in states:
             states[NodeFeature.AVAILABLE] = self.available_state

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -633,9 +633,9 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
                 case NodeFeature.PING:
                     states[NodeFeature.PING] = await self.ping_update()
                 case _:
-                    raise NodeError(
+                    _LOGGER.debug(
                         f"Update of feature '{feature.name}' is "
-                        + f"not supported for {self.mac}"
+                        + f"does not return any data {self.mac}"
                     )
 
         return states

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -529,7 +529,8 @@ class PlugwiseScan(NodeSED):
                     states[NodeFeature.MOTION_CONFIG] = self._motion_config
                 case _:
                     state_result = await super().get_state((feature,))
-                    states[feature] = state_result[feature]
+                    if feature in state_result:
+                        states[feature] = state_result[feature]
 
         if NodeFeature.AVAILABLE not in states:
             states[NodeFeature.AVAILABLE] = self.available_state

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -647,6 +647,7 @@ class NodeSED(PlugwiseBaseNode):
                     states[NodeFeature.BATTERY] = self._battery_config
                 case _:
                     state_result = await super().get_state((feature,))
-                    states[feature] = state_result[feature]
+                    if feature in state_result:
+                        states[feature] = state_result[feature]
 
         return states

--- a/plugwise_usb/nodes/sense.py
+++ b/plugwise_usb/nodes/sense.py
@@ -165,7 +165,8 @@ class PlugwiseSense(NodeSED):
                     states[NodeFeature.SENSE] = self._sense_statistics
                 case _:
                     state_result = await super().get_state((feature,))
-                    states[feature] = state_result[feature]
+                    if feature in state_result:
+                        states[feature] = state_result[feature]
 
         if NodeFeature.AVAILABLE not in states:
             states[NodeFeature.AVAILABLE] = self.available_state

--- a/plugwise_usb/nodes/switch.py
+++ b/plugwise_usb/nodes/switch.py
@@ -154,7 +154,8 @@ class PlugwiseSwitch(NodeSED):
                     states[NodeFeature.SWITCH] = self._switch
                 case _:
                     state_result = await super().get_state((feature,))
-                    states[feature] = state_result[feature]
+                    if feature in state_result:
+                        states[feature] = state_result[feature]
 
         if NodeFeature.AVAILABLE not in states:
             states[NodeFeature.AVAILABLE] = self.available_state


### PR DESCRIPTION
Some NodeFeatures are not carrying any data, however they are used to generate entities such as buttons in HA. If polling requests data for these features, no data should be returned, and no exception generated.