### PR TITLE
Line up energy_logs cache-content with energy_logs collection in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Ongoing
+## 0.44.14 - 2025-08-31
 
 - PR [329](https://github.com/plugwise/python-plugwise-usb/pull/329): Improve EnergyLogs caching: store only data from MAX_LOG_HOURS (24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- PR [329](https://github.com/plugwise/python-plugwise-usb/pull/329): Improve EnergyLogs caching: store only data from MAX_LOG_HOURS (24)
+
 ## v0.44.13 - 2025-08-29
 
 - PR [327](https://github.com/plugwise/python-plugwise-usb/pull/327): Improve code quality according to SonarCloud, simplify sed awake timer

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -432,7 +432,9 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 # Retry with previous log address as Circle node pointer to self._current_log_address
                 # could be rolled over while the last log is at previous address/slot
                 prev_log_address, _ = calc_log_address(self._current_log_address, 1, -4)
-                result = await self.energy_log_update(prev_log_address, save_cache=False)
+                result = await self.energy_log_update(
+                    prev_log_address, save_cache=False
+                )
                 if not result:
                     _LOGGER.debug(
                         "async_energy_update | %s | Log rollover | energy_log_update from address %s failed",
@@ -612,13 +614,15 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 self._energy_counters.add_empty_log(response.log_address, _slot)
                 continue
 
-            cache_updated = await self._energy_log_record_update_state(
+            updated = await self._energy_log_record_update_state(
                 response.log_address,
                 _slot,
                 log_timestamp.replace(tzinfo=UTC),
                 log_pulses,
                 import_only=True,
             )
+            if updated:
+                cache_updated = True
 
         self._energy_counters.update()
         if cache_updated and save_cache:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -583,9 +583,10 @@ class PlugwiseCircle(PlugwiseBaseNode):
     ) -> tuple[bool, bool]:
         """Request energy logs from node and store them.
 
-        Return first bool as True if processing succeeded (records stored in memory, possibly all-empty).
-        Return first bool as False on transport or address errors.
-        Return second bool as False when all slots are empty or outdated; otherwise True.
+        First bool: True when processing succeeded (records stored in memory, possibly all-empty);
+        False only on transport or address errors.
+        Second bool: slots_empty — True when all four slots at the address are empty or outdated;
+        False when at least one recent, non-empty record was stored.
         """
         result = False
         slots_empty = True
@@ -618,17 +619,13 @@ class PlugwiseCircle(PlugwiseBaseNode):
             _LOGGER.debug(
                 "In slot=%s: pulses=%s, timestamp=%s", _slot, log_pulses, log_timestamp
             )
+            address = response.log_address
+            log_timestamp = log_timestamp.replace(tzinfo=UTC)
             if log_timestamp is None or log_pulses is None:
-                self._energy_counters.add_empty_log(response.log_address, _slot)
-            elif self._check_timestamp_is_recent(
-                response.log_address, _slot, log_timestamp.replace(tzinfo=UTC)
-            ):
+                self._energy_counters.add_empty_log(address, _slot)
+            elif self._check_timestamp_is_recent(address, _slot, log_timestamp):
                 self._energy_counters.add_pulse_log(
-                    response.log_address,
-                    _slot,
-                    log_timestamp.replace(tzinfo=UTC),
-                    log_pulses,
-                    import_only=True,
+                    address, _slot, log_timestamp, log_pulses, import_only=True,
                 )
                 cache_updated = True
 

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -725,8 +725,14 @@ class PlugwiseCircle(PlugwiseBaseNode):
         import_only: bool = False,
     ) -> bool:
         """Process new energy log record. Returns true if record is new or changed."""
+        _LOGGER.warning(
+            "EnergyLogs before update: %s", self._energy_counters.get_pulse_logs()
+        )
         self._energy_counters.add_pulse_log(
             address, slot, timestamp, pulses, import_only=import_only
+        )
+        _LOGGER.warning(
+            "EnergyLogs after update: %s", self._energy_counters.get_pulse_logs()
         )
         if not self._cache_enabled:
             return False

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -418,7 +418,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
 
             # Try collecting energy-stats for _current_log_address
             result = await self.energy_log_update(
-                self._current_log_address, save_cache=True
+                self._current_log_address, save_cache=False
             )
             if not result:
                 _LOGGER.debug(
@@ -432,7 +432,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 # Retry with previous log address as Circle node pointer to self._current_log_address
                 # could be rolled over while the last log is at previous address/slot
                 prev_log_address, _ = calc_log_address(self._current_log_address, 1, -4)
-                result = await self.energy_log_update(prev_log_address, save_cache=True)
+                result = await self.energy_log_update(prev_log_address, save_cache=False)
                 if not result:
                     _LOGGER.debug(
                         "async_energy_update | %s | Log rollover | energy_log_update from address %s failed",

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -578,7 +578,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
     ) -> bool:
         """Request energy logs from node and store them.
 
-        Return True if processing succeeded (records stored in memory), regardless of whether new entries were added.
+        Return True if processing succeeded: records stored in memory, also for empty slots.
         Return False on transport or address errors.
         """
         if address is None:

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -577,9 +577,10 @@ class PlugwiseCircle(PlugwiseBaseNode):
         self, address: int | None, save_cache: bool = True
     ) -> bool:
         """Request energy logs from node and store them.
-        
+
         Return True if processing succeeded (records stored in memory), regardless of whether new entries were added.
-        Return False on transport or address errors."""
+        Return False on transport or address errors.
+        """
         if address is None:
             return False
 

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -441,6 +441,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     )
                     return None
 
+            await self.save_cache()
+
         if (
             missing_addresses := self._energy_counters.log_addresses_missing
         ) is not None:
@@ -529,6 +531,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
             log_address, _ = calc_log_address(log_address, 1, -4)
             total_addresses -= 1
 
+        await self.save_cache()
+
     async def get_missing_energy_logs(self) -> None:
         """Task to retrieve missing energy logs."""
         self._energy_counters.update()
@@ -561,6 +565,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 # Drain cancellations to avoid "Task exception was never retrieved"
                 await gather(*to_cancel, return_exceptions=True)
                 break
+
+        await self.save_cache()
 
     async def energy_log_update(
         self, address: int | None, save_cache: bool = True

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -441,7 +441,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     )
                     return None
 
-            await self.save_cache()
+            if self._cache_enabled:
+                await self.save_cache()
 
         if (
             missing_addresses := self._energy_counters.log_addresses_missing
@@ -531,7 +532,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
             log_address, _ = calc_log_address(log_address, 1, -4)
             total_addresses -= 1
 
-        await self.save_cache()
+        if self._cache_enabled:
+            await self.save_cache()
 
     async def get_missing_energy_logs(self) -> None:
         """Task to retrieve missing energy logs."""
@@ -566,7 +568,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 await gather(*to_cancel, return_exceptions=True)
                 break
 
-        await self.save_cache()
+        if self._cache_enabled:
+            await self.save_cache()
 
     async def energy_log_update(
         self, address: int | None, save_cache: bool = True

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -625,11 +625,13 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 cache_updated = True
 
         self._energy_counters.update()
-        if cache_updated and save_cache:
-            _LOGGER.debug(
-                "Saving energy record update to cache for %s", self._mac_in_str
-            )
-            await self.save_cache()
+        if cache_updated:
+            await self._energy_log_records_save_to_cache()
+            if save_cache:
+                _LOGGER.debug(
+                    "Saving energy record update to cache for %s", self._mac_in_str
+                )
+                await self.save_cache()
 
         return True
 
@@ -748,7 +750,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     str(slot),
                     self._mac_in_str,
                 )
-                await self._energy_log_records_save_to_cache()
                 return True
 
             _LOGGER.debug(
@@ -762,7 +763,6 @@ class PlugwiseCircle(PlugwiseBaseNode):
             str(slot),
             self._mac_in_str,
         )
-        await self._energy_log_records_save_to_cache()
         return True
 
     @raise_not_loaded

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -749,12 +749,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                     str(slot),
                     self._mac_in_str,
                 )
-                new_cache = (
-                    f"{log_cache_record}|{cached_logs}"
-                    if cached_logs
-                    else log_cache_record
-                )
-                self._set_cache(CACHE_ENERGY_COLLECTION, new_cache)
+                self._energy_log_records_save_to_cache()
                 await self.save_cache(trigger_only=True)
                 return True
 
@@ -769,7 +764,8 @@ class PlugwiseCircle(PlugwiseBaseNode):
             str(slot),
             self._mac_in_str,
         )
-        self._set_cache(CACHE_ENERGY_COLLECTION, log_cache_record)
+        self._energy_log_records_save_to_cache()
+        await self.save_cache(trigger_only=True)
         return True
 
     @raise_not_loaded

--- a/plugwise_usb/nodes/circle.py
+++ b/plugwise_usb/nodes/circle.py
@@ -576,7 +576,10 @@ class PlugwiseCircle(PlugwiseBaseNode):
     async def energy_log_update(
         self, address: int | None, save_cache: bool = True
     ) -> bool:
-        """Request energy logs and return True only when at least one recent, non-empty record was stored; otherwise return False."""
+        """Request energy logs from node and store them.
+        
+        Return True if processing succeeded (records stored in memory), regardless of whether new entries were added.
+        Return False on transport or address errors."""
         if address is None:
             return False
 
@@ -1186,7 +1189,7 @@ class PlugwiseCircle(PlugwiseBaseNode):
                 NodeFeature.RELAY_INIT, self._relay_config
             )
             _LOGGER.debug(
-                "Saving relay_init state update to cachefor %s", self._mac_in_str
+                "Saving relay_init state update to cache for %s", self._mac_in_str
             )
             await self.save_cache()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.14a1"
+version         = "0.44.14a2"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.14a0"
+version         = "0.44.14a1"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.14a2"
+version         = "0.44.14a3"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.13"
+version         = "0.44.14a0"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.44.14a3"
+version         = "0.44.14"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [


### PR DESCRIPTION
This PR implements my alternative idea to store the contents of `self.logs` into the `energy-collection` cache entry: a copy of the (limited to 24h) energy-log data in memory is stored on disk instead of a separate collection that keeps on growing because no pruning of older data was implemented.

Also, an inconsistency (re-)introduced in `energy_log_update()` was solved.

Finally, various suggestions from the Rabbit were implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined energy-log caching to prefer in-memory updates with centralized, conditional disk saves; improved handling during log rollovers and initial sync to reduce I/O and improve stability.
* **Bug Fixes**
  * Fixed a minor log message typo.
* **Documentation**
  * Added CHANGELOG entry documenting EnergyLogs caching improvements.
* **Chores**
  * Bumped package version to 0.44.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->