### PR TITLE
Improve node_type caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- PR [342](https://github.com/plugwise/python-plugwise-usb/pull/342): Improve node_type chaching.
+
 ## 0.46.0 - 2025-09-12
 
 - PR [338](https://github.com/plugwise/python-plugwise-usb/pull/338): Append report interval to Sense node configuration

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -29,10 +29,10 @@ class NetworkRegistrationCache(PlugwiseCache):
         cache_data_to_save: dict[str, str] = {}
         for mac, node_type in self._nodetypes.items():
             cache_data_to_save[mac] = node_type.name
-        _LOGGER.debug("Save NodeTypes for %s Nodes", (len(cache_data_to_save)))
+        _LOGGER.debug("Save NodeTypes for %s Nodes", len(cache_data_to_save))
         await self.write_cache(
             cache_data_to_save, True
-        )  # rewrite set to True is required
+        )  # rewrite set to True to make sure the cache-contents is actual
 
     async def clear_cache(self) -> None:
         """Clear current cache."""

--- a/plugwise_usb/network/cache.py
+++ b/plugwise_usb/network/cache.py
@@ -26,13 +26,11 @@ class NetworkRegistrationCache(PlugwiseCache):
 
     async def save_cache(self) -> None:
         """Save the node information to file."""
-        cache_data_to_save: dict[str, str] = {}
-        for mac, node_type in self._nodetypes.items():
-            cache_data_to_save[mac] = node_type.name
+        cache_data_to_save: dict[str, str] = {
+            mac: node_type.name for mac, node_type in self._nodetypes.items()
+        }
         _LOGGER.debug("Save NodeTypes for %s Nodes", len(cache_data_to_save))
-        await self.write_cache(
-            cache_data_to_save, True
-        )  # rewrite set to True to make sure the cache-contents is actual
+        await self.write_cache(cache_data_to_save, rewrite=True)  # Make sure the cache-contents is actual
 
     async def clear_cache(self) -> None:
         """Clear current cache."""
@@ -56,7 +54,7 @@ class NetworkRegistrationCache(PlugwiseCache):
                     node_type = None
 
             if node_type is None:
-                _LOGGER.warning("Invalid NodeType in cache: %s", node_value)
+                _LOGGER.warning("Invalid NodeType in cache for mac %s: %s", mac, node_value)
                 continue
             self._nodetypes[mac] = node_type
             _LOGGER.debug(

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1712,9 +1712,9 @@ class TestStick:
 
         # test with valid data
         mock_read_data = [
-            "0123456789ABCDEF;NodeType.CIRCLE_PLUS",
+            "0123456789ABCDEF;CIRCLE_PLUS",
             "FEDCBA9876543210;NodeType.CIRCLE",
-            "1298347650AFBECD;NodeType.SCAN",
+            "1298347650AFBECD;6",
         ]
         file_chunks_iter = iter(mock_read_data)
         mock_file_stream = MagicMock(readlines=lambda *args, **kwargs: file_chunks_iter)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1733,10 +1733,10 @@ class TestStick:
             )
             mock_file_stream.writelines.assert_called_with(
                 [
-                    "0123456789ABCDEF;NodeType.CIRCLE_PLUS\n",
-                    "FEDCBA9876543210;NodeType.CIRCLE\n",
-                    "1298347650AFBECD;NodeType.SCAN\n",
-                    "1234ABCD4321FEDC;NodeType.STEALTH\n",
+                    "0123456789ABCDEF;CIRCLE_PLUS\n",
+                    "FEDCBA9876543210;CIRCLE\n",
+                    "1298347650AFBECD;SCAN\n",
+                    "1234ABCD4321FEDC;STEALTH\n",
                 ]
             )
         assert pw_nw_cache.nodetypes == {


### PR DESCRIPTION
All changes:
- Save NodeType name to file: e.g. "0123456789ABCDEF;CIRCLE"
- Read all present and previously used node_type string-formats from cache-file
- Fix CIRCLE_PLUS not appearing in cache-file
- Make sure to rewrite the full contents at every write-to-file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust device-type cache handling: accepts enum names, full enum text, or numeric codes; avoids unnecessary writes and improves logging when restoring/pruning cache.

* **Tests**
  * Updated tests to reflect the simplified cache serialization format (short node type identifiers and numeric codes).

* **Documentation**
  * Added an “Ongoing” section to CHANGELOG noting the cache improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->