### PR TITLE
Fix auto-joining not functioning as intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - PR [337](https://github.com/plugwise/python-plugwise-usb/pull/337): Improve node removal, remove and reset the node as executed by Source, and remove the cache-file.
 - PR [342](https://github.com/plugwise/python-plugwise-usb/pull/342): Improve node_type chaching.
 - PR [343](https://github.com/plugwise/python-plugwise-usb/pull/343): Improve writing of cache-files.
-- PR [344](https://github.com/plugwise/python-plugwise-usb/pull/344): Don't store plus-device in nodetypes cache
+- PR [344](https://github.com/plugwise/python-plugwise-usb/pull/344): Don't store plus-device in nodetypes cache.
+- PR [348](https://github.com/plugwise/python-plugwise-usb/pull/348): Fix broken auto-joining.
 
 ## 0.46.0 - 2025-09-12
 

--- a/plugwise_usb/network/registry.py
+++ b/plugwise_usb/network/registry.py
@@ -263,8 +263,6 @@ class StickNetworkRegister:
             await request.send()
         except StickError as exc:
             raise NodeError(f"{exc}") from exc
-        if self.update_network_registration(mac):
-            await self._exec_node_discover_callback(mac, None, False)
 
     async def unregister_node(self, node: PlugwiseNode) -> None:
         """Unregister node from current Plugwise network."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Adjusted node registration flow: newly added devices are no longer auto-listed immediately upon add; appearance now depends on subsequent discovery. This may affect the timing of when new devices show up after registration.

- Documentation
  - Updated the ongoing changelog to split and note recent pull requests, including adding a new entry and clarifying an existing one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->