### PR TITLE
Change logging from warning to debug to reduce logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 repos:
   # Run manually in CI skipping the branch checks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: v0.15.20
     hooks:
       - id: ruff
         name: "Ruff check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 repos:
   # Run manually in CI skipping the branch checks
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.19
     hooks:
       - id: ruff
         name: "Ruff check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: yamllint
         name: "YAML linting"
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.5.0
+    rev: v2.5.1
     hooks:
       - id: biome-lint
         name: "Verifying/updating code with biome (improved prettier)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.47.8 - 2026-07-01
+
+PR [459](https://github.com/plugwise/python-plugwise-usb/pull/459): Reduce logging for SEDs
+
 ## v0.47.7 - 2026-05-18
 
 PR [443](https://github.com/plugwise/python-plugwise-usb/pull/443): Migrate to serialx

--- a/plugwise_usb/nodes/node.py
+++ b/plugwise_usb/nodes/node.py
@@ -379,7 +379,7 @@ class PlugwiseBaseNode(FeaturePublisher, ABC):
         if self._loaded:
             return True
         if not self._cache_enabled:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Unable to load node %s from cache because caching is disabled",
                 self.mac,
             )

--- a/plugwise_usb/nodes/scan.py
+++ b/plugwise_usb/nodes/scan.py
@@ -357,7 +357,7 @@ class PlugwiseScan(NodeSED):
             raise MessageError(
                 f"Invalid response message type ({response.__class__.__name__}) received, expected NodeSwitchGroupResponse"
             )
-        _LOGGER.warning("%s received %s", self.name, response)
+        _LOGGER.debug("%s received %s", self.name, response)
         await gather(
             self._available_update_state(True, response.timestamp),
             self._motion_state_update(response.switch_state, response.timestamp),
@@ -393,7 +393,7 @@ class PlugwiseScan(NodeSED):
                         )
                         await self._scan_configure_update()
                     elif reset_timer < self._motion_config.reset_timer:
-                        _LOGGER.warning(
+                        _LOGGER.debug(
                             "Adjust reset timer for %s from %s -> %s",
                             self.name,
                             self._motion_config.reset_timer,

--- a/plugwise_usb/nodes/sed.py
+++ b/plugwise_usb/nodes/sed.py
@@ -477,7 +477,7 @@ class NodeSED(PlugwiseBaseNode):
             timestamp - self._last_awake[NodeAwakeResponseType.MAINTENANCE]
         ).seconds
         new_interval_in_min = round(new_interval_in_sec // 60)
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Detect current maintenance interval for %s: %s (seconds), current %s (min)",
             self.name,
             new_interval_in_sec,
@@ -528,7 +528,7 @@ class NodeSED(PlugwiseBaseNode):
         # Mark node as unavailable
         if self._available:
             last_awake = self._last_awake.get(NodeAwakeResponseType.MAINTENANCE)
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "No awake message received from %s | last_maintenance_awake=%s | interval=%s (%s) | Marking node as unavailable",
                 self.name,
                 last_awake,

--- a/plugwise_usb/nodes/sense.py
+++ b/plugwise_usb/nodes/sense.py
@@ -619,7 +619,7 @@ class PlugwiseSense(NodeSED):
             raise MessageError(
                 f"Invalid response message type ({response.__class__.__name__}) received, expected NodeSwitchGroupResponse"
             )
-        _LOGGER.warning("%s received %s", self.name, response)
+        _LOGGER.debug("%s received %s", self.name, response)
         await gather(
             self._available_update_state(True, response.timestamp),
             self._hysteresis_state_update(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise_usb"
-version         = "0.47.7"
+version         = "0.47.8"
 license         = "MIT"
 keywords        = ["home", "automation", "plugwise", "module", "usb"]
 classifiers     = [


### PR DESCRIPTION
Some of the battery nodes warning are really debug-related messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced logging verbosity by downgrading several routine operational messages from warning to debug across node scanning, sense/switch group handling, SED maintenance/awake timer scenarios, and cache-disabled behavior.
* **Documentation**
  * Added a new changelog entry for version **0.47.8** noting reduced SED logging verbosity.
* **Chores**
  * Bumped pre-commit hook versions and updated the package version to **0.47.8**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->